### PR TITLE
Update svg assets in rendering chapter

### DIFF
--- a/content/learn/book/rendering/3d/camera/Various_projections_of_cube_above_plane.svg
+++ b/content/learn/book/rendering/3d/camera/Various_projections_of_cube_above_plane.svg
@@ -1,3004 +1,903 @@
-<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
-
-<svg 
-     version="1.1"
-     baseProfile="full"
-     xmlns="http://www.w3.org/2000/svg"
-     xmlns:xlink="http://www.w3.org/1999/xlink"
-     xmlns:ev="http://www.w3.org/2001/xml-events"
-     width="640px"
-     height="480px"
-     viewBox="-640 -480 1280 960"
-     >
-<title>
-
-</title>
-<!-- IMAGE1 PERSPECTIVE **************************************************** -->
-<g stroke-linejoin="miter" stroke-dashoffset="0.0000" stroke-dasharray="none" stroke-width="1.0000" stroke-miterlimit="10.000" stroke-linecap="square" transform="translate(-640,-480)">
-<g id="misc">
-</g><!-- misc -->
-<g id="layer0">
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipe9db062d-7ad3-429f-b158-2a1036910d97">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip1)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 68.500 232.00 L 68.500 253.00 C 68.500 254.38 69.619 255.50 71.000 255.50 L 92.000 255.50 C 93.381 255.50 94.500 254.38 94.500 253.00 L 94.500 232.00 C 94.500 230.62 93.381 229.50 92.000 229.50 L 71.000 229.50 C 69.619 229.50 68.500 230.62 68.500 232.00 z"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip1 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipa4c1c3c0-cc5d-47ea-bc38-ce5c8a615c72">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip2)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#ffffff">
-  <path d="M 69.000 232.50 L 69.000 251.50 C 69.000 252.88 70.119 254.00 71.500 254.00 L 90.500 254.00 C 91.881 254.00 93.000 252.88 93.000 251.50 L 93.000 232.50 C 93.000 231.12 91.881 230.00 90.500 230.00 L 71.500 230.00 C 70.119 230.00 69.000 231.12 69.000 232.50 z"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip2 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipe792b571-222f-4d91-85ef-dd0f983246ef">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip3)">
-<g stroke-linejoin="round" stroke-width="4.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#444444">
-  <path d="M 73.500 244.50 L 78.500 249.50"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip3 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip6778395d-e0f9-45d9-be93-798057c9dfec">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip4)">
-<g stroke-linejoin="round" stroke-width="4.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#444444">
-  <path d="M 78.500 249.50 L 88.500 235.50"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip4 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipd6b5e203-d8af-4d54-ae59-58dc6f53d678">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip5)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 107.16 249.00 L 107.16 238.89 L 103.38 238.89 L 103.38 237.55 L 112.45 237.55 L 112.45 238.89 L 108.67 238.89 L 108.67 249.00 L 107.16 249.00 z M 113.30 244.84 Q 113.30 242.55 114.59 241.44 Q 115.66 240.52 117.20 240.52 Q 118.91 240.52 120.00 241.63 Q 121.09 242.75 121.09 244.73 Q 121.09 246.33 120.60 247.25 Q 120.12 248.17 119.20 248.68 Q 118.29 249.19 117.20 249.19 Q 115.46 249.19 114.38 248.07 Q 113.30 246.95 113.30 244.84 z M 114.76 244.84 Q 114.76 246.44 115.45 247.23 Q 116.15 248.03 117.20 248.03 Q 118.24 248.03 118.94 247.23 Q 119.63 246.44 119.63 244.80 Q 119.63 243.27 118.94 242.47 Q 118.24 241.67 117.20 241.67 Q 116.15 241.67 115.45 242.46 Q 114.76 243.25 114.76 244.84 z M 122.47 249.69 L 123.84 249.89 Q 123.92 250.53 124.31 250.81 Q 124.84 251.20 125.75 251.20 Q 126.72 251.20 127.25 250.81 Q 127.78 250.42 127.97 249.72 Q 128.08 249.30 128.08 247.91 Q 127.16 249.00 125.78 249.00 Q 124.06 249.00 123.12 247.77 Q 122.19 246.53 122.19 244.80 Q 122.19 243.61 122.62 242.61 Q 123.05 241.61 123.87 241.06 Q 124.69 240.52 125.78 240.52 Q 127.25 240.52 128.20 241.70 L 128.20 240.70 L 129.50 240.70 L 129.50 247.88 Q 129.50 249.81 129.11 250.62 Q 128.72 251.44 127.86 251.91 Q 127.00 252.38 125.75 252.38 Q 124.27 252.38 123.35 251.70 Q 122.44 251.03 122.47 249.69 z M 123.64 244.70 Q 123.64 246.33 124.29 247.08 Q 124.94 247.83 125.91 247.83 Q 126.88 247.83 127.53 247.09 Q 128.19 246.34 128.19 244.75 Q 128.19 243.22 127.52 242.45 Q 126.84 241.67 125.89 241.67 Q 124.95 241.67 124.30 242.44 Q 123.64 243.20 123.64 244.70 z M 131.37 249.69 L 132.74 249.89 Q 132.82 250.53 133.21 250.81 Q 133.74 251.20 134.65 251.20 Q 135.62 251.20 136.15 250.81 Q 136.68 250.42 136.87 249.72 Q 136.98 249.30 136.98 247.91 Q 136.05 249.00 134.68 249.00 Q 132.96 249.00 132.02 247.77 Q 131.09 246.53 131.09 244.80 Q 131.09 243.61 131.52 242.61 Q 131.95 241.61 132.77 241.06 Q 133.59 240.52 134.68 240.52 Q 136.15 240.52 137.10 241.70 L 137.10 240.70 L 138.40 240.70 L 138.40 247.88 Q 138.40 249.81 138.01 250.62 Q 137.62 251.44 136.76 251.91 Q 135.90 252.38 134.65 252.38 Q 133.16 252.38 132.25 251.70 Q 131.34 251.03 131.37 249.69 z M 132.54 244.70 Q 132.54 246.33 133.19 247.08 Q 133.84 247.83 134.80 247.83 Q 135.77 247.83 136.43 247.09 Q 137.09 246.34 137.09 244.75 Q 137.09 243.22 136.41 242.45 Q 135.74 241.67 134.79 241.67 Q 133.85 241.67 133.20 242.44 Q 132.54 243.20 132.54 244.70 z M 140.50 249.00 L 140.50 237.55 L 141.91 237.55 L 141.91 249.00 L 140.50 249.00 z M 149.76 246.33 L 151.21 246.50 Q 150.87 247.78 149.94 248.48 Q 149.01 249.19 147.57 249.19 Q 145.74 249.19 144.68 248.06 Q 143.62 246.94 143.62 244.92 Q 143.62 242.83 144.70 241.67 Q 145.77 240.52 147.49 240.52 Q 149.15 240.52 150.20 241.65 Q 151.26 242.78 151.26 244.83 Q 151.26 244.95 151.26 245.20 L 145.07 245.20 Q 145.15 246.58 145.84 247.30 Q 146.54 248.03 147.57 248.03 Q 148.35 248.03 148.90 247.62 Q 149.45 247.22 149.76 246.33 z M 145.15 244.05 L 149.77 244.05 Q 149.68 243.00 149.24 242.48 Q 148.57 241.67 147.51 241.67 Q 146.54 241.67 145.88 242.32 Q 145.21 242.97 145.15 244.05 z M 157.63 249.00 L 157.63 237.55 L 165.91 237.55 L 165.91 238.89 L 159.15 238.89 L 159.15 242.41 L 165.49 242.41 L 165.49 243.75 L 159.15 243.75 L 159.15 247.64 L 166.18 247.64 L 166.18 249.00 L 157.63 249.00 z M 167.16 249.00 L 170.20 244.69 L 167.38 240.70 L 169.15 240.70 L 170.41 242.64 Q 170.77 243.20 170.99 243.58 Q 171.34 243.06 171.63 242.66 L 173.02 240.70 L 174.71 240.70 L 171.84 244.61 L 174.93 249.00 L 173.20 249.00 L 171.49 246.42 L 171.04 245.72 L 168.87 249.00 L 167.16 249.00 z M 176.10 252.19 L 176.10 240.70 L 177.38 240.70 L 177.38 241.78 Q 177.84 241.14 178.41 240.83 Q 178.98 240.52 179.79 240.52 Q 180.85 240.52 181.66 241.06 Q 182.48 241.61 182.89 242.60 Q 183.30 243.59 183.30 244.78 Q 183.30 246.06 182.84 247.08 Q 182.38 248.09 181.52 248.64 Q 180.65 249.19 179.68 249.19 Q 178.98 249.19 178.42 248.89 Q 177.87 248.59 177.51 248.14 L 177.51 252.19 L 176.10 252.19 z M 177.37 244.89 Q 177.37 246.50 178.02 247.27 Q 178.66 248.03 179.59 248.03 Q 180.52 248.03 181.20 247.23 Q 181.87 246.44 181.87 244.78 Q 181.87 243.19 181.21 242.40 Q 180.55 241.61 179.65 241.61 Q 178.76 241.61 178.06 242.45 Q 177.37 243.30 177.37 244.89 z M 184.47 244.84 Q 184.47 242.55 185.75 241.44 Q 186.83 240.52 188.36 240.52 Q 190.08 240.52 191.16 241.63 Q 192.25 242.75 192.25 244.73 Q 192.25 246.33 191.77 247.25 Q 191.28 248.17 190.37 248.68 Q 189.45 249.19 188.36 249.19 Q 186.62 249.19 185.55 248.07 Q 184.47 246.95 184.47 244.84 z M 185.92 244.84 Q 185.92 246.44 186.62 247.23 Q 187.31 248.03 188.36 248.03 Q 189.41 248.03 190.10 247.23 Q 190.80 246.44 190.80 244.80 Q 190.80 243.27 190.10 242.47 Q 189.41 241.67 188.36 241.67 Q 187.31 241.67 186.62 242.46 Q 185.92 243.25 185.92 244.84 z M 193.88 249.00 L 193.88 240.70 L 195.15 240.70 L 195.15 241.95 Q 195.63 241.08 196.04 240.80 Q 196.45 240.52 196.95 240.52 Q 197.65 240.52 198.38 240.97 L 197.90 242.27 Q 197.38 241.97 196.87 241.97 Q 196.41 241.97 196.05 242.24 Q 195.68 242.52 195.52 243.02 Q 195.29 243.77 195.29 244.66 L 195.29 249.00 L 193.88 249.00 z M 202.29 247.73 L 202.49 248.98 Q 201.90 249.11 201.43 249.11 Q 200.66 249.11 200.24 248.87 Q 199.82 248.62 199.65 248.23 Q 199.48 247.83 199.48 246.56 L 199.48 241.80 L 198.45 241.80 L 198.45 240.70 L 199.48 240.70 L 199.48 238.64 L 200.88 237.80 L 200.88 240.70 L 202.29 240.70 L 202.29 241.80 L 200.88 241.80 L 200.88 246.64 Q 200.88 247.25 200.95 247.42 Q 201.02 247.59 201.20 247.70 Q 201.37 247.80 201.68 247.80 Q 201.91 247.80 202.29 247.73 z M 208.32 249.00 L 208.32 237.55 L 216.60 237.55 L 216.60 238.89 L 209.84 238.89 L 209.84 242.41 L 216.18 242.41 L 216.18 243.75 L 209.84 243.75 L 209.84 247.64 L 216.87 247.64 L 216.87 249.00 L 208.32 249.00 z M 224.16 249.00 L 224.16 247.95 Q 223.38 249.19 221.85 249.19 Q 220.85 249.19 220.02 248.64 Q 219.20 248.09 218.73 247.11 Q 218.27 246.12 218.27 244.86 Q 218.27 243.61 218.69 242.60 Q 219.10 241.59 219.93 241.05 Q 220.76 240.52 221.79 240.52 Q 222.54 240.52 223.12 240.83 Q 223.71 241.14 224.07 241.66 L 224.07 237.55 L 225.48 237.55 L 225.48 249.00 L 224.16 249.00 z M 219.73 244.86 Q 219.73 246.45 220.40 247.24 Q 221.07 248.03 221.98 248.03 Q 222.90 248.03 223.55 247.27 Q 224.20 246.52 224.20 244.97 Q 224.20 243.27 223.54 242.47 Q 222.88 241.67 221.91 241.67 Q 220.98 241.67 220.35 242.44 Q 219.73 243.20 219.73 244.86 z M 227.42 249.69 L 228.80 249.89 Q 228.88 250.53 229.27 250.81 Q 229.80 251.20 230.70 251.20 Q 231.67 251.20 232.20 250.81 Q 232.73 250.42 232.92 249.72 Q 233.03 249.30 233.03 247.91 Q 232.11 249.00 230.73 249.00 Q 229.02 249.00 228.08 247.77 Q 227.14 246.53 227.14 244.80 Q 227.14 243.61 227.57 242.61 Q 228.00 241.61 228.82 241.06 Q 229.64 240.52 230.73 240.52 Q 232.20 240.52 233.16 241.70 L 233.16 240.70 L 234.45 240.70 L 234.45 247.88 Q 234.45 249.81 234.06 250.62 Q 233.67 251.44 232.81 251.91 Q 231.95 252.38 230.70 252.38 Q 229.22 252.38 228.30 251.70 Q 227.39 251.03 227.42 249.69 z M 228.59 244.70 Q 228.59 246.33 229.24 247.08 Q 229.89 247.83 230.86 247.83 Q 231.83 247.83 232.48 247.09 Q 233.14 246.34 233.14 244.75 Q 233.14 243.22 232.47 242.45 Q 231.80 241.67 230.84 241.67 Q 229.91 241.67 229.25 242.44 Q 228.59 243.20 228.59 244.70 z M 242.26 246.33 L 243.71 246.50 Q 243.37 247.78 242.44 248.48 Q 241.51 249.19 240.07 249.19 Q 238.24 249.19 237.18 248.06 Q 236.12 246.94 236.12 244.92 Q 236.12 242.83 237.20 241.67 Q 238.27 240.52 239.99 240.52 Q 241.65 240.52 242.70 241.65 Q 243.76 242.78 243.76 244.83 Q 243.76 244.95 243.76 245.20 L 237.57 245.20 Q 237.65 246.58 238.34 247.30 Q 239.04 248.03 240.07 248.03 Q 240.85 248.03 241.40 247.62 Q 241.95 247.22 242.26 246.33 z M 237.65 244.05 L 242.27 244.05 Q 242.18 243.00 241.74 242.48 Q 241.07 241.67 240.01 241.67 Q 239.04 241.67 238.38 242.32 Q 237.71 242.97 237.65 244.05 z M 244.92 246.52 L 246.31 246.30 Q 246.42 247.14 246.96 247.59 Q 247.50 248.03 248.45 248.03 Q 249.42 248.03 249.89 247.63 Q 250.36 247.23 250.36 246.70 Q 250.36 246.23 249.95 245.95 Q 249.66 245.77 248.52 245.48 Q 246.97 245.09 246.37 244.80 Q 245.77 244.52 245.46 244.02 Q 245.16 243.52 245.16 242.91 Q 245.16 242.34 245.41 241.88 Q 245.66 241.41 246.09 241.09 Q 246.42 240.84 246.99 240.68 Q 247.56 240.52 248.20 240.52 Q 249.19 240.52 249.92 240.80 Q 250.66 241.08 251.01 241.55 Q 251.36 242.03 251.50 242.84 L 250.12 243.03 Q 250.03 242.39 249.58 242.03 Q 249.12 241.67 248.31 241.67 Q 247.34 241.67 246.93 241.99 Q 246.52 242.31 246.52 242.73 Q 246.52 243.02 246.69 243.23 Q 246.86 243.45 247.22 243.61 Q 247.44 243.69 248.47 243.97 Q 249.95 244.36 250.55 244.62 Q 251.14 244.88 251.48 245.36 Q 251.81 245.84 251.81 246.56 Q 251.81 247.27 251.40 247.88 Q 250.98 248.50 250.21 248.84 Q 249.44 249.19 248.47 249.19 Q 246.84 249.19 246.00 248.52 Q 245.16 247.84 244.92 246.52 z"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip5 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip895d0752-d7f4-4970-a9e0-872ba779760d">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip6)">
-<g fill-opacity=".24706" fill-rule="evenodd" stroke="none" fill="#a0a0a0">
-  <path d="M 854.24 566.27 L 857.60 337.36 L 976.73 240.08 L 966.46 454.07 z"/>
-<title>Quadrilateral pane_{poly}</title>
-<desc>Quadrilateral pane_{poly}: Polygon pane_A, pane_D, pane_C, pane_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip6 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip4fe172a9-4c20-418e-bdb3-e320af2518c7">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip7)">
-<g fill-opacity="1.0000" fill-rule="evenodd" stroke="none" fill="#a0a0a0">
-  <path d="M 507.77 494.65 L 703.50 350.73 L 1097.5 458.03 L 940.35 636.55 z"/>
-<title>Quadrilateral base_{poly}</title>
-<desc>Quadrilateral base_{poly}: Polygon base_D, base_C, base_B, base_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip7 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipf43da612-9322-4e4b-8bf3-e54150e3a015">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip8)">
-<g fill-opacity="1.0000" fill-rule="evenodd" stroke="none" fill="#808080">
-  <path d="M 619.90 488.66 L 653.52 462.19 L 702.94 477.32 L 670.03 504.52 z"/>
-<title>Quadrilateral shad_{poly}</title>
-<desc>Quadrilateral shad_{poly}: Polygon shad_E, shad_F, shad_B, shad_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip8 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipd19dbc9b-dfa7-426f-a787-84815f69bb3b">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip9)">
-<g fill-opacity="1.0000" fill-rule="evenodd" stroke="none" fill="#0099ff">
-  <path d="M 616.66 432.04 L 650.93 406.44 L 701.16 421.07 L 702.80 472.95 L 669.84 500.08 L 619.64 484.26 z"/>
-<title>Hexagon cube_{poly}</title>
-<desc>Hexagon cube_{poly}: Polygon cube_H, cube_G, cube_C, cube_B, cube_A, cube_E</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip9 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip7398e7b6-429b-4e07-ab41-bd61be739432">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip10)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 906.28 400.46 L 912.65 386.78"/>
-<title>Segment proj_l</title>
-<desc>Segment proj_l: Segment proj_D, proj_H</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip10 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipa839e6bf-a165-4f9d-a9a6-dbb2b8590445">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip11)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 912.65 386.78 L 926.22 374.60"/>
-<title>Segment proj_m</title>
-<desc>Segment proj_m: Segment proj_H, proj_G</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip11 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipafe3d57e-7e23-4093-b749-443905521fb2">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip12)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 926.22 374.60 L 921.76 386.47"/>
-<title>Segment proj_n</title>
-<desc>Segment proj_n: Segment proj_G, proj_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip12 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipf31fe44b-c921-4a1d-9c5e-877a35f074d5">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip13)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 921.76 386.47 L 906.28 400.46"/>
-<title>Segment proj_p</title>
-<desc>Segment proj_p: Segment proj_C, proj_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip13 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip28f864fb-05a4-4ca6-9013-206cbb022faf">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip14)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 926.22 374.60 L 925.31 400.54"/>
-<title>Segment proj_q</title>
-<desc>Segment proj_q: Segment proj_G, proj_F</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip14 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipc7962e6a-e4b2-41b3-94cf-fa3511b46a81">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip15)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 925.31 400.54 L 920.77 415.76"/>
-<title>Segment proj_r</title>
-<desc>Segment proj_r: Segment proj_F, proj_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip15 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipc5def63c-12fb-4bf4-8882-681df4748d01">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip16)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 920.77 415.76 L 921.76 386.47"/>
-<title>Segment proj_s</title>
-<desc>Segment proj_s: Segment proj_B, proj_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip16 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip6f20c4fc-e288-4d53-a77b-df040968f48f">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip17)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 920.77 415.76 L 905.41 430.01"/>
-<title>Segment proj_t</title>
-<desc>Segment proj_t: Segment proj_B, proj_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip17 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip931ce32e-d03a-474b-83c0-57a2053a17cc">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip18)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 905.41 430.01 L 906.28 400.46"/>
-<title>Segment proj_f</title>
-<desc>Segment proj_f: Segment proj_A, proj_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip18 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip426f9996-c189-4171-9a01-e5885af92b2f">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip19)">
-<g stroke-linejoin="round" stroke-width="2.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 1127.3 201.76 L 1127.3 681.76"/>
-<title>Segment edge_m</title>
-<desc>Segment edge_m: Segment Export_2, edge_F</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip19 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip19ecc32d-06ef-4239-8cc0-7d4221eadb56">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip20)">
-<g stroke-linejoin="round" stroke-width="2.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 1127.3 681.76 L 487.34 681.76"/>
-<title>Segment edge_n</title>
-<desc>Segment edge_n: Segment edge_F, Export_1</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip20 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip0382394a-1b94-45d7-9ce8-6739321521a0">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip21)">
-<g stroke-linejoin="round" stroke-width="2.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 487.34 681.76 L 487.34 201.76"/>
-<title>Segment edge_o</title>
-<desc>Segment edge_o: Segment Export_1, edge_G</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip21 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipd2ef9c54-2282-44a9-b3cc-532e724c1a50">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip22)">
-<g stroke-linejoin="round" stroke-width="2.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 487.34 201.76 L 1127.3 201.76"/>
-<title>Segment edge_l</title>
-<desc>Segment edge_l: Segment edge_G, Export_2</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip22 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip52e1251f-99ef-4544-80c2-bad645d4ab35">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip23)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 940.35 636.55 L 1097.5 458.03"/>
-<title>Segment base_a</title>
-<desc>Segment base_a: Segment base_A, base_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip23 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipa3f21cdd-f83d-49c2-9e94-e4ffdd0bdc19">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip24)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 1097.5 458.03 L 703.50 350.73"/>
-<title>Segment base_c</title>
-<desc>Segment base_c: Segment base_B, base_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip24 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip8e7065e8-2737-4243-a6ea-05cd92b6536c">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip25)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 619.90 488.66 L 670.03 504.52"/>
-<title>Segment shad_m</title>
-<desc>Segment shad_m: Segment shad_E, shad_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip25 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip6fa24452-fba1-4de6-84c2-9e28b7a104ea">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip26)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 670.03 504.52 L 702.94 477.32"/>
-<title>Segment shad_n</title>
-<desc>Segment shad_n: Segment shad_A, shad_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip26 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip68c5f122-aeb7-476c-9684-2e7a0df0123c">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip27)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 616.66 432.04 L 619.64 484.26"/>
-<title>Segment cube_m</title>
-<desc>Segment cube_m: Segment cube_H, cube_E</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip27 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipf6f93b32-ed0e-4f85-8fc4-cc68f397cfa8">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip28)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 619.64 484.26 L 669.84 500.08"/>
-<title>Segment cube_n</title>
-<desc>Segment cube_n: Segment cube_E, cube_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip28 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip4ef626f3-1b2f-46e1-9985-dac6f6df2d41">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip29)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 669.84 500.08 L 702.80 472.95"/>
-<title>Segment cube_o</title>
-<desc>Segment cube_o: Segment cube_A, cube_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip29 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip0450dbaa-2aad-431d-9e8c-89451f7cd38c">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip30)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 702.80 472.95 L 701.16 421.07"/>
-<title>Segment cube_p</title>
-<desc>Segment cube_p: Segment cube_B, cube_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip30 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipc41c22bc-08e2-442c-8530-a8d52fc90121">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip31)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 701.16 421.07 L 650.93 406.44"/>
-<title>Segment cube_q</title>
-<desc>Segment cube_q: Segment cube_C, cube_G</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip31 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip32fa3cb6-a5e7-4ced-a964-c080e425c83a">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip32)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 650.93 406.44 L 616.66 432.04"/>
-<title>Segment cube_r</title>
-<desc>Segment cube_r: Segment cube_G, cube_H</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip32 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipd406cf27-7edf-4c11-ae4e-36ea005e9a33">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip33)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 616.66 432.04 L 667.63 447.39"/>
-<title>Segment cube_s</title>
-<desc>Segment cube_s: Segment cube_H, cube_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip33 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipda84d5e9-5820-4e46-a811-5620b96cdced">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip34)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 667.63 447.39 L 669.84 500.08"/>
-<title>Segment cube_t</title>
-<desc>Segment cube_t: Segment cube_D, cube_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip34 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipfa0f83ec-5d4b-4ab0-892d-a264f739d671">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip35)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 667.63 447.39 L 701.16 421.07"/>
-<title>Segment cube_l</title>
-<desc>Segment cube_l: Segment cube_D, cube_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip35 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip602d3454-f681-4c90-960d-594b86550679">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip36)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 619.90 488.66 L 623.82 485.57"/>
-<title>Segment shad_o</title>
-<desc>Segment shad_o: Segment shad_E, shad_L</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip36 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip088f9ef7-7a7e-404c-914c-ac0de346b5e0">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip37)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 698.97 476.10 L 702.94 477.32"/>
-<title>Segment shad_p</title>
-<desc>Segment shad_p: Segment shad_M, shad_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip37 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip8f5a177f-6177-403e-b1a9-4e293f2c4b6e">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip38)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 857.60 337.36 L 976.73 240.08"/>
-<title>Segment pane_a</title>
-<desc>Segment pane_a: Segment pane_D, pane_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip38 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip9a14bc8f-0bd6-49f7-a058-8de63058f47e">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip39)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 976.73 240.08 L 966.46 454.07"/>
-<title>Segment pane_b</title>
-<desc>Segment pane_b: Segment pane_C, pane_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip39 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipb75b79f3-027e-4460-8817-2531c0d7bdf2">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip40)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 966.46 454.07 L 854.24 566.27"/>
-<title>Segment pane_c</title>
-<desc>Segment pane_c: Segment pane_B, pane_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip40 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipbc728b15-3f6c-4a69-834d-10a5c8411636">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip41)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 854.24 566.27 L 857.60 337.36"/>
-<title>Segment pane_d</title>
-<desc>Segment pane_d: Segment pane_A, pane_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip41 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipc3b50399-3e1e-4c8f-a35d-19426b944c02">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip42)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 701.16 421.07 L 1197.0 343.29"/>
-<title>Segment vect_c</title>
-<desc>Segment vect_c: Segment cube_C, cent_X</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip42 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip0bf765a7-981a-4bd2-915b-68d263ef472a">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip43)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 702.80 472.95 L 1197.0 343.29"/>
-<title>Segment vect_d</title>
-<desc>Segment vect_d: Segment cube_B, cent_X</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip43 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip19ae7735-ed0e-44f1-82ff-fd3cfc71daeb">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip44)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 669.84 500.08 L 1197.0 343.29"/>
-<title>Segment vect_e</title>
-<desc>Segment vect_e: Segment cube_A, cent_X</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip44 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip316bd5d1-ea7e-4f8c-a537-2532ad7586c1">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip45)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 702.00 447.59 L 1197.0 343.29"/>
-<title>Segment vect_j</title>
-<desc>Segment vect_j: Segment vect_A, cent_X</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip45 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipbf31e999-8deb-433f-86a0-7d6bf22e33b9">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip46)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 616.66 432.04 L 1197.0 343.29"/>
-<title>Segment vect_u</title>
-<desc>Segment vect_u: Segment cube_H, cent_X</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip46 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipf2d20f2d-e760-4296-b3c8-31592ec5ae86">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip47)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 650.93 406.44 L 1197.0 343.29"/>
-<title>Segment vect_v</title>
-<desc>Segment vect_v: Segment cube_G, cent_X</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip47 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip72dc92d3-0b63-429c-98ec-0c0f7f0f8ff1">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip48)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 667.63 447.39 L 1197.0 343.29"/>
-<title>Segment vect_w</title>
-<desc>Segment vect_w: Segment cube_D, cent_X</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip48 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip8f307f74-0391-4d5a-86df-84900d18faf3">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip49)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 507.77 494.65 L 703.50 350.73"/>
-<title>Segment base_d</title>
-<desc>Segment base_d: Segment base_D, base_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip49 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip0e4a671e-d283-41d9-97cb-d9f44d90d3ce">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip50)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 507.77 494.65 L 940.35 636.55"/>
-<title>Segment base_b</title>
-<desc>Segment base_b: Segment base_D, base_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip50 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip27813090-3f17-4110-b844-a74b08b2ee04">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip51)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 1202.0 343.29 C 1202.0 346.05 1199.7 348.29 1197.0 348.29 C 1194.2 348.29 1192.0 346.05 1192.0 343.29 C 1192.0 340.53 1194.2 338.29 1197.0 338.29 C 1199.7 338.29 1202.0 340.53 1202.0 343.29 z"/>
-<title>Point cent_X</title>
-<desc>Point cent_X: Point({1108.81775, 528.855})</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip51 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipbbca4491-b62f-4ecc-8d0e-8ff8683c213f">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip52)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 1202.0 343.29 C 1202.0 346.05 1199.7 348.29 1197.0 348.29 C 1194.2 348.29 1192.0 346.05 1192.0 343.29 C 1192.0 340.53 1194.2 338.29 1197.0 338.29 C 1199.7 338.29 1202.0 340.53 1202.0 343.29 z"/>
-<title>Point cent_X</title>
-<desc>Point cent_X: Point({1108.81775, 528.855})</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip52 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipfa6b6848-a903-4186-a0f0-6ad90c591629">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip53)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 522.02 250.00 L 519.66 250.00 L 522.05 238.55 L 526.70 238.55 Q 527.95 238.55 528.67 238.84 Q 529.39 239.12 529.81 239.80 Q 530.23 240.48 530.23 241.42 Q 530.23 242.28 529.90 243.10 Q 529.56 243.92 529.08 244.41 Q 528.59 244.91 528.03 245.16 Q 527.47 245.42 526.52 245.55 Q 525.95 245.62 524.44 245.62 L 522.92 245.62 L 522.02 250.00 z M 523.31 243.73 L 524.05 243.73 Q 525.91 243.73 526.53 243.50 Q 527.16 243.27 527.52 242.75 Q 527.88 242.23 527.88 241.61 Q 527.88 241.20 527.70 240.94 Q 527.52 240.67 527.18 240.55 Q 526.84 240.42 525.70 240.42 L 524.02 240.42 L 523.31 243.73 z M 530.33 250.00 L 532.72 238.55 L 541.22 238.55 L 540.81 240.45 L 534.69 240.45 L 534.14 243.06 L 540.06 243.06 L 539.67 244.97 L 533.73 244.97 L 533.02 248.08 L 539.69 248.08 L 539.28 250.00 L 530.33 250.00 z M 543.41 250.00 L 541.05 250.00 L 543.45 238.55 L 548.53 238.55 Q 549.84 238.55 550.58 238.81 Q 551.31 239.08 551.76 239.80 Q 552.20 240.52 552.20 241.55 Q 552.20 243.00 551.33 243.95 Q 550.45 244.91 548.69 245.12 Q 549.14 245.53 549.53 246.20 Q 550.33 247.55 551.30 250.00 L 548.77 250.00 Q 548.45 249.03 547.56 246.97 Q 547.08 245.86 546.53 245.48 Q 546.20 245.25 545.36 245.25 L 544.41 245.25 L 543.41 250.00 z M 544.77 243.53 L 546.02 243.53 Q 547.91 243.53 548.53 243.30 Q 549.16 243.08 549.51 242.59 Q 549.86 242.11 549.86 241.58 Q 549.86 240.95 549.34 240.64 Q 549.03 240.45 548.00 240.45 L 545.41 240.45 L 544.77 243.53 z M 552.91 246.28 L 555.16 246.17 Q 555.21 247.23 555.52 247.61 Q 556.04 248.22 557.43 248.22 Q 558.59 248.22 559.10 247.80 Q 559.62 247.39 559.62 246.81 Q 559.62 246.30 559.20 245.95 Q 558.90 245.69 557.57 245.11 Q 556.24 244.53 555.62 244.15 Q 555.01 243.77 554.66 243.15 Q 554.30 242.53 554.30 241.70 Q 554.30 240.25 555.35 239.30 Q 556.40 238.34 558.38 238.34 Q 560.40 238.34 561.51 239.29 Q 562.62 240.23 562.73 241.81 L 560.46 241.91 Q 560.38 241.09 559.88 240.66 Q 559.37 240.22 558.37 240.22 Q 557.40 240.22 556.98 240.56 Q 556.55 240.91 556.55 241.42 Q 556.55 241.92 556.95 242.23 Q 557.32 242.56 558.63 243.14 Q 560.62 243.98 561.15 244.52 Q 561.96 245.30 561.96 246.53 Q 561.96 248.05 560.76 249.12 Q 559.55 250.20 557.41 250.20 Q 555.95 250.20 554.86 249.70 Q 553.77 249.20 553.33 248.32 Q 552.88 247.44 552.91 246.28 z M 565.59 250.00 L 563.23 250.00 L 565.62 238.55 L 570.27 238.55 Q 571.52 238.55 572.24 238.84 Q 572.96 239.12 573.38 239.80 Q 573.80 240.48 573.80 241.42 Q 573.80 242.28 573.47 243.10 Q 573.13 243.92 572.65 244.41 Q 572.16 244.91 571.60 245.16 Q 571.04 245.42 570.09 245.55 Q 569.52 245.62 568.01 245.62 L 566.49 245.62 L 565.59 250.00 z M 566.88 243.73 L 567.62 243.73 Q 569.48 243.73 570.10 243.50 Q 570.73 243.27 571.09 242.75 Q 571.45 242.23 571.45 241.61 Q 571.45 241.20 571.27 240.94 Q 571.09 240.67 570.75 240.55 Q 570.41 240.42 569.27 240.42 L 567.59 240.42 L 566.88 243.73 z M 573.90 250.00 L 576.29 238.55 L 584.79 238.55 L 584.38 240.45 L 578.26 240.45 L 577.71 243.06 L 583.63 243.06 L 583.24 244.97 L 577.30 244.97 L 576.59 248.08 L 583.26 248.08 L 582.85 250.00 L 573.90 250.00 z M 592.87 245.88 L 595.24 246.23 Q 594.55 248.16 593.16 249.18 Q 591.77 250.20 589.90 250.20 Q 587.80 250.20 586.62 248.94 Q 585.43 247.67 585.43 245.27 Q 585.43 243.31 586.23 241.69 Q 587.02 240.06 588.43 239.20 Q 589.84 238.34 591.49 238.34 Q 593.35 238.34 594.50 239.34 Q 595.65 240.34 595.85 242.06 L 593.59 242.28 Q 593.40 241.28 592.87 240.83 Q 592.34 240.38 591.45 240.38 Q 590.46 240.38 589.62 240.97 Q 588.77 241.56 588.27 242.83 Q 587.76 244.09 587.76 245.34 Q 587.76 246.72 588.41 247.47 Q 589.07 248.22 590.05 248.22 Q 590.98 248.22 591.73 247.62 Q 592.49 247.03 592.87 245.88 z M 601.11 250.00 L 598.75 250.00 L 600.75 240.45 L 597.39 240.45 L 597.80 238.55 L 606.81 238.55 L 606.42 240.45 L 603.11 240.45 L 601.11 250.00 z M 605.80 250.00 L 608.20 238.55 L 610.55 238.55 L 608.16 250.00 L 605.80 250.00 z M 616.08 250.00 L 613.56 250.00 L 611.50 238.55 L 613.86 238.55 L 615.31 247.20 L 620.05 238.55 L 622.39 238.55 L 616.08 250.00 z M 621.02 250.00 L 623.41 238.55 L 631.91 238.55 L 631.50 240.45 L 625.38 240.45 L 624.83 243.06 L 630.75 243.06 L 630.36 244.97 L 624.42 244.97 L 623.70 248.08 L 630.38 248.08 L 629.97 250.00 L 621.02 250.00 z"/>
-<title>PERSPECTIVE</title>
-<desc>text16 = “PERSPECTIVE”</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip53 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip29be7711-53b4-409b-9ccb-ecc796bda833">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip54)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#ffffff">
-  <path d="M 67.000 92.000 L 67.000 123.00 C 67.000 125.21 68.791 127.00 71.000 127.00 L 310.00 127.00 C 312.21 127.00 314.00 125.21 314.00 123.00 L 314.00 92.000 C 314.00 89.791 312.21 88.000 310.00 88.000 L 71.000 88.000 C 68.791 88.000 67.000 89.791 67.000 92.000 z"/>
-<title>Button button2</title>
-<desc>button2</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip54 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipd84bdc6b-b2f8-40a0-8926-4d948a1e2ea6">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip55)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 67.500 92.500 L 67.500 123.50 C 67.500 125.71 69.291 127.50 71.500 127.50 L 310.50 127.50 C 312.71 127.50 314.50 125.71 314.50 123.50 L 314.50 92.500 C 314.50 90.291 312.71 88.500 310.50 88.500 L 71.500 88.500 C 69.291 88.500 67.500 90.291 67.500 92.500 z"/>
-<title>Button button2</title>
-<desc>button2</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip55 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipcc2dd358-8c57-4741-9978-fc774d0dad21">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip56)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 90.109 110.97 L 92.391 111.55 Q 91.672 114.34 89.812 115.82 Q 87.953 117.30 85.266 117.30 Q 82.500 117.30 80.758 116.16 Q 79.016 115.03 78.109 112.88 Q 77.203 110.73 77.203 108.28 Q 77.203 105.59 78.227 103.59 Q 79.250 101.59 81.141 100.56 Q 83.031 99.531 85.312 99.531 Q 87.891 99.531 89.648 100.84 Q 91.406 102.16 92.094 104.53 L 89.859 105.06 Q 89.250 103.19 88.117 102.33 Q 86.984 101.47 85.266 101.47 Q 83.281 101.47 81.953 102.42 Q 80.625 103.38 80.086 104.97 Q 79.547 106.56 79.547 108.27 Q 79.547 110.45 80.180 112.09 Q 80.812 113.73 82.164 114.54 Q 83.516 115.34 85.078 115.34 Q 87.000 115.34 88.320 114.24 Q 89.641 113.14 90.109 110.97 z M 94.863 117.00 L 94.863 99.812 L 96.973 99.812 L 96.973 117.00 L 94.863 117.00 z M 100.26 102.25 L 100.26 99.812 L 102.37 99.812 L 102.37 102.25 L 100.26 102.25 z M 100.26 117.00 L 100.26 104.55 L 102.37 104.55 L 102.37 117.00 L 100.26 117.00 z M 113.70 112.44 L 115.78 112.70 Q 115.43 114.86 114.04 116.07 Q 112.64 117.28 110.59 117.28 Q 108.04 117.28 106.49 115.61 Q 104.93 113.94 104.93 110.83 Q 104.93 108.81 105.61 107.30 Q 106.28 105.78 107.64 105.02 Q 109.00 104.27 110.61 104.27 Q 112.64 104.27 113.93 105.30 Q 115.21 106.33 115.57 108.20 L 113.53 108.53 Q 113.23 107.27 112.49 106.63 Q 111.75 106.00 110.68 106.00 Q 109.09 106.00 108.10 107.15 Q 107.11 108.30 107.11 110.77 Q 107.11 113.27 108.07 114.41 Q 109.03 115.55 110.57 115.55 Q 111.81 115.55 112.64 114.78 Q 113.48 114.02 113.70 112.44 z M 117.59 117.00 L 117.59 99.812 L 119.70 99.812 L 119.70 109.61 L 124.70 104.55 L 127.42 104.55 L 122.67 109.17 L 127.90 117.00 L 125.31 117.00 L 121.18 110.64 L 119.70 112.06 L 119.70 117.00 L 117.59 117.00 z M 140.88 117.00 L 140.88 101.84 L 135.23 101.84 L 135.23 99.812 L 148.85 99.812 L 148.85 101.84 L 143.16 101.84 L 143.16 117.00 L 140.88 117.00 z M 153.20 117.00 L 149.40 104.55 L 151.57 104.55 L 153.56 111.73 L 154.29 114.41 Q 154.34 114.20 154.93 111.84 L 156.92 104.55 L 159.09 104.55 L 160.95 111.77 L 161.57 114.16 L 162.29 111.75 L 164.42 104.55 L 166.46 104.55 L 162.57 117.00 L 160.39 117.00 L 158.40 109.55 L 157.93 107.42 L 155.40 117.00 L 153.20 117.00 z M 168.25 102.25 L 168.25 99.812 L 170.36 99.812 L 170.36 102.25 L 168.25 102.25 z M 168.25 117.00 L 168.25 104.55 L 170.36 104.55 L 170.36 117.00 L 168.25 117.00 z M 181.69 112.44 L 183.77 112.70 Q 183.43 114.86 182.03 116.07 Q 180.63 117.28 178.58 117.28 Q 176.04 117.28 174.48 115.61 Q 172.93 113.94 172.93 110.83 Q 172.93 108.81 173.60 107.30 Q 174.27 105.78 175.63 105.02 Q 176.99 104.27 178.60 104.27 Q 180.63 104.27 181.92 105.30 Q 183.21 106.33 183.57 108.20 L 181.52 108.53 Q 181.22 107.27 180.48 106.63 Q 179.74 106.00 178.68 106.00 Q 177.08 106.00 176.09 107.15 Q 175.10 108.30 175.10 110.77 Q 175.10 113.27 176.06 114.41 Q 177.02 115.55 178.57 115.55 Q 179.80 115.55 180.64 114.78 Q 181.47 114.02 181.69 112.44 z M 194.10 112.98 L 196.27 113.27 Q 195.75 115.17 194.36 116.23 Q 192.97 117.28 190.80 117.28 Q 188.07 117.28 186.46 115.60 Q 184.86 113.92 184.86 110.88 Q 184.86 107.73 186.48 106.00 Q 188.10 104.27 190.68 104.27 Q 193.18 104.27 194.76 105.97 Q 196.35 107.67 196.35 110.75 Q 196.35 110.94 196.33 111.31 L 187.05 111.31 Q 187.16 113.36 188.21 114.45 Q 189.25 115.55 190.82 115.55 Q 191.97 115.55 192.79 114.94 Q 193.61 114.33 194.10 112.98 z M 187.16 109.58 L 194.11 109.58 Q 193.97 108.02 193.32 107.22 Q 192.32 106.00 190.71 106.00 Q 189.25 106.00 188.26 106.98 Q 187.27 107.95 187.16 109.58 z M 210.19 115.11 L 210.50 116.97 Q 209.61 117.17 208.91 117.17 Q 207.75 117.17 207.12 116.80 Q 206.49 116.44 206.23 115.84 Q 205.97 115.25 205.97 113.36 L 205.97 106.19 L 204.43 106.19 L 204.43 104.55 L 205.97 104.55 L 205.97 101.47 L 208.07 100.20 L 208.07 104.55 L 210.19 104.55 L 210.19 106.19 L 208.07 106.19 L 208.07 113.47 Q 208.07 114.38 208.18 114.63 Q 208.30 114.89 208.55 115.04 Q 208.80 115.19 209.27 115.19 Q 209.61 115.19 210.19 115.11 z M 211.47 110.78 Q 211.47 107.31 213.39 105.66 Q 215.00 104.27 217.31 104.27 Q 219.88 104.27 221.50 105.95 Q 223.12 107.64 223.12 110.59 Q 223.12 113.00 222.41 114.38 Q 221.69 115.75 220.31 116.52 Q 218.94 117.28 217.31 117.28 Q 214.69 117.28 213.08 115.60 Q 211.47 113.92 211.47 110.78 z M 213.64 110.78 Q 213.64 113.17 214.68 114.36 Q 215.72 115.55 217.31 115.55 Q 218.88 115.55 219.92 114.35 Q 220.97 113.16 220.97 110.70 Q 220.97 108.39 219.91 107.20 Q 218.86 106.02 217.31 106.02 Q 215.72 106.02 214.68 107.20 Q 213.64 108.39 213.64 110.78 z M 232.58 117.00 L 232.58 99.812 L 240.19 99.812 Q 242.48 99.812 243.68 100.28 Q 244.88 100.75 245.59 101.92 Q 246.31 103.09 246.31 104.50 Q 246.31 106.33 245.12 107.59 Q 243.94 108.84 241.47 109.19 Q 242.38 109.61 242.84 110.03 Q 243.84 110.95 244.73 112.33 L 247.72 117.00 L 244.86 117.00 L 242.58 113.42 Q 241.59 111.88 240.95 111.05 Q 240.30 110.23 239.79 109.91 Q 239.28 109.58 238.75 109.45 Q 238.36 109.38 237.48 109.38 L 234.84 109.38 L 234.84 117.00 L 232.58 117.00 z M 234.84 107.41 L 239.73 107.41 Q 241.30 107.41 242.17 107.08 Q 243.05 106.75 243.51 106.05 Q 243.97 105.34 243.97 104.50 Q 243.97 103.28 243.09 102.50 Q 242.20 101.72 240.28 101.72 L 234.84 101.72 L 234.84 107.41 z M 258.13 112.98 L 260.30 113.27 Q 259.79 115.17 258.39 116.23 Q 257.00 117.28 254.83 117.28 Q 252.10 117.28 250.50 115.60 Q 248.89 113.92 248.89 110.88 Q 248.89 107.73 250.51 106.00 Q 252.13 104.27 254.71 104.27 Q 257.21 104.27 258.79 105.97 Q 260.38 107.67 260.38 110.75 Q 260.38 110.94 260.36 111.31 L 251.08 111.31 Q 251.19 113.36 252.24 114.45 Q 253.29 115.55 254.85 115.55 Q 256.00 115.55 256.82 114.94 Q 257.64 114.33 258.13 112.98 z M 251.19 109.58 L 258.14 109.58 Q 258.00 108.02 257.35 107.22 Q 256.35 106.00 254.74 106.00 Q 253.29 106.00 252.29 106.98 Q 251.30 107.95 251.19 109.58 z M 262.10 113.28 L 264.20 112.95 Q 264.37 114.20 265.17 114.88 Q 265.98 115.55 267.41 115.55 Q 268.87 115.55 269.57 114.95 Q 270.27 114.36 270.27 113.56 Q 270.27 112.84 269.65 112.44 Q 269.23 112.16 267.49 111.72 Q 265.18 111.14 264.28 110.71 Q 263.38 110.28 262.92 109.52 Q 262.46 108.77 262.46 107.86 Q 262.46 107.03 262.84 106.32 Q 263.23 105.61 263.88 105.14 Q 264.37 104.78 265.22 104.52 Q 266.07 104.27 267.04 104.27 Q 268.51 104.27 269.62 104.69 Q 270.73 105.11 271.25 105.84 Q 271.77 106.56 271.98 107.77 L 269.91 108.05 Q 269.77 107.08 269.10 106.54 Q 268.43 106.00 267.20 106.00 Q 265.74 106.00 265.12 106.48 Q 264.49 106.97 264.49 107.61 Q 264.49 108.02 264.76 108.34 Q 265.01 108.69 265.57 108.91 Q 265.88 109.03 267.43 109.45 Q 269.66 110.05 270.55 110.43 Q 271.43 110.81 271.94 111.54 Q 272.45 112.27 272.45 113.34 Q 272.45 114.39 271.83 115.33 Q 271.21 116.27 270.05 116.77 Q 268.90 117.28 267.43 117.28 Q 265.01 117.28 263.73 116.27 Q 262.46 115.27 262.10 113.28 z M 274.96 102.25 L 274.96 99.812 L 277.07 99.812 L 277.07 102.25 L 274.96 102.25 z M 274.96 117.00 L 274.96 104.55 L 277.07 104.55 L 277.07 117.00 L 274.96 117.00 z M 279.17 117.00 L 279.17 115.28 L 287.09 106.19 Q 285.75 106.27 284.71 106.27 L 279.64 106.27 L 279.64 104.55 L 289.81 104.55 L 289.81 105.95 L 283.07 113.84 L 281.78 115.28 Q 283.18 115.19 284.43 115.19 L 290.18 115.19 L 290.18 117.00 L 279.17 117.00 z M 300.81 112.98 L 302.98 113.27 Q 302.46 115.17 301.07 116.23 Q 299.68 117.28 297.51 117.28 Q 294.78 117.28 293.18 115.60 Q 291.57 113.92 291.57 110.88 Q 291.57 107.73 293.19 106.00 Q 294.81 104.27 297.39 104.27 Q 299.89 104.27 301.47 105.97 Q 303.06 107.67 303.06 110.75 Q 303.06 110.94 303.04 111.31 L 293.76 111.31 Q 293.87 113.36 294.92 114.45 Q 295.96 115.55 297.53 115.55 Q 298.68 115.55 299.50 114.94 Q 300.32 114.33 300.81 112.98 z M 293.87 109.58 L 300.82 109.58 Q 300.68 108.02 300.03 107.22 Q 299.03 106.00 297.42 106.00 Q 295.96 106.00 294.97 106.98 Q 293.98 107.95 293.87 109.58 z"/>
-<title>Button button2</title>
-<desc>button2</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip56 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip9d7d27e6-952e-4950-a413-0278f302e827">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip57)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#ffffff">
-  <path d="M 58.000 176.00 L 58.000 207.00 C 58.000 209.21 59.791 211.00 62.000 211.00 L 273.00 211.00 C 275.21 211.00 277.00 209.21 277.00 207.00 L 277.00 176.00 C 277.00 173.79 275.21 172.00 273.00 172.00 L 62.000 172.00 C 59.791 172.00 58.000 173.79 58.000 176.00 z"/>
-<title>Button button1</title>
-<desc>button1</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip57 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clip40fbc62e-e5e1-4982-820c-877dc7257107">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip58)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 58.500 176.50 L 58.500 207.50 C 58.500 209.71 60.291 211.50 62.500 211.50 L 273.50 211.50 C 275.71 211.50 277.50 209.71 277.50 207.50 L 277.50 176.50 C 277.50 174.29 275.71 172.50 273.50 172.50 L 62.500 172.50 C 60.291 172.50 58.500 174.29 58.500 176.50 z"/>
-<title>Button button1</title>
-<desc>button1</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip58 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -487.34, -201.76)">
-<clipPath id="clipbb8179c5-1aa8-42dc-a080-f66f4659db5f">
-  <path d="M 487.34 201.76 L 487.34 683.76 L 1129.3 683.76 L 1129.3 201.76 z"/>
-</clipPath>
-<g clip-path="url(#clip59)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 81.109 194.97 L 83.391 195.55 Q 82.672 198.34 80.812 199.82 Q 78.953 201.30 76.266 201.30 Q 73.500 201.30 71.758 200.16 Q 70.016 199.03 69.109 196.88 Q 68.203 194.73 68.203 192.28 Q 68.203 189.59 69.227 187.59 Q 70.250 185.59 72.141 184.56 Q 74.031 183.53 76.312 183.53 Q 78.891 183.53 80.648 184.84 Q 82.406 186.16 83.094 188.53 L 80.859 189.06 Q 80.250 187.19 79.117 186.33 Q 77.984 185.47 76.266 185.47 Q 74.281 185.47 72.953 186.42 Q 71.625 187.38 71.086 188.97 Q 70.547 190.56 70.547 192.27 Q 70.547 194.45 71.180 196.09 Q 71.812 197.73 73.164 198.54 Q 74.516 199.34 76.078 199.34 Q 78.000 199.34 79.320 198.24 Q 80.641 197.14 81.109 194.97 z M 85.863 201.00 L 85.863 183.81 L 87.973 183.81 L 87.973 201.00 L 85.863 201.00 z M 91.258 186.25 L 91.258 183.81 L 93.367 183.81 L 93.367 186.25 L 91.258 186.25 z M 91.258 201.00 L 91.258 188.55 L 93.367 188.55 L 93.367 201.00 L 91.258 201.00 z M 104.70 196.44 L 106.78 196.70 Q 106.43 198.86 105.04 200.07 Q 103.64 201.28 101.59 201.28 Q 99.043 201.28 97.488 199.61 Q 95.934 197.94 95.934 194.83 Q 95.934 192.81 96.605 191.30 Q 97.277 189.78 98.637 189.02 Q 99.996 188.27 101.61 188.27 Q 103.64 188.27 104.93 189.30 Q 106.21 190.33 106.57 192.20 L 104.53 192.53 Q 104.23 191.27 103.49 190.63 Q 102.75 190.00 101.68 190.00 Q 100.09 190.00 99.098 191.15 Q 98.105 192.30 98.105 194.77 Q 98.105 197.27 99.066 198.41 Q 100.03 199.55 101.57 199.55 Q 102.81 199.55 103.64 198.78 Q 104.48 198.02 104.70 196.44 z M 108.59 201.00 L 108.59 183.81 L 110.70 183.81 L 110.70 193.61 L 115.70 188.55 L 118.42 188.55 L 113.67 193.17 L 118.90 201.00 L 116.31 201.00 L 112.18 194.64 L 110.70 196.06 L 110.70 201.00 L 108.59 201.00 z M 131.85 199.11 L 132.16 200.97 Q 131.27 201.17 130.57 201.17 Q 129.41 201.17 128.78 200.80 Q 128.15 200.44 127.89 199.84 Q 127.63 199.25 127.63 197.36 L 127.63 190.19 L 126.09 190.19 L 126.09 188.55 L 127.63 188.55 L 127.63 185.47 L 129.73 184.20 L 129.73 188.55 L 131.85 188.55 L 131.85 190.19 L 129.73 190.19 L 129.73 197.47 Q 129.73 198.38 129.84 198.63 Q 129.96 198.89 130.21 199.04 Q 130.46 199.19 130.93 199.19 Q 131.27 199.19 131.85 199.11 z M 133.13 194.78 Q 133.13 191.31 135.05 189.66 Q 136.66 188.27 138.97 188.27 Q 141.54 188.27 143.16 189.95 Q 144.79 191.64 144.79 194.59 Q 144.79 197.00 144.07 198.38 Q 143.35 199.75 141.97 200.52 Q 140.60 201.28 138.97 201.28 Q 136.35 201.28 134.74 199.60 Q 133.13 197.92 133.13 194.78 z M 135.30 194.78 Q 135.30 197.17 136.34 198.36 Q 137.38 199.55 138.97 199.55 Q 140.54 199.55 141.58 198.35 Q 142.63 197.16 142.63 194.70 Q 142.63 192.39 141.57 191.20 Q 140.52 190.02 138.97 190.02 Q 137.38 190.02 136.34 191.20 Q 135.30 192.39 135.30 194.78 z M 154.21 201.00 L 154.21 183.81 L 160.68 183.81 Q 162.39 183.81 163.30 183.98 Q 164.57 184.19 165.42 184.78 Q 166.27 185.38 166.79 186.45 Q 167.32 187.52 167.32 188.78 Q 167.32 190.98 165.92 192.50 Q 164.52 194.02 160.88 194.02 L 156.47 194.02 L 156.47 201.00 L 154.21 201.00 z M 156.47 191.98 L 160.91 191.98 Q 163.11 191.98 164.04 191.16 Q 164.97 190.34 164.97 188.86 Q 164.97 187.78 164.43 187.02 Q 163.88 186.25 162.99 186.00 Q 162.41 185.84 160.86 185.84 L 156.47 185.84 L 156.47 191.98 z M 169.89 201.00 L 169.89 183.81 L 172.00 183.81 L 172.00 201.00 L 169.89 201.00 z M 174.48 194.78 Q 174.48 191.31 176.41 189.66 Q 178.02 188.27 180.33 188.27 Q 182.89 188.27 184.52 189.95 Q 186.14 191.64 186.14 194.59 Q 186.14 197.00 185.42 198.38 Q 184.70 199.75 183.33 200.52 Q 181.95 201.28 180.33 201.28 Q 177.70 201.28 176.09 199.60 Q 174.48 197.92 174.48 194.78 z M 176.66 194.78 Q 176.66 197.17 177.70 198.36 Q 178.73 199.55 180.33 199.55 Q 181.89 199.55 182.94 198.35 Q 183.98 197.16 183.98 194.70 Q 183.98 192.39 182.93 191.20 Q 181.88 190.02 180.33 190.02 Q 178.73 190.02 177.70 191.20 Q 176.66 192.39 176.66 194.78 z M 193.22 199.11 L 193.54 200.97 Q 192.64 201.17 191.94 201.17 Q 190.79 201.17 190.15 200.80 Q 189.52 200.44 189.26 199.84 Q 189.00 199.25 189.00 197.36 L 189.00 190.19 L 187.46 190.19 L 187.46 188.55 L 189.00 188.55 L 189.00 185.47 L 191.10 184.20 L 191.10 188.55 L 193.22 188.55 L 193.22 190.19 L 191.10 190.19 L 191.10 197.47 Q 191.10 198.38 191.21 198.63 Q 191.33 198.89 191.58 199.04 Q 191.83 199.19 192.30 199.19 Q 192.64 199.19 193.22 199.11 z M 202.23 201.00 L 202.23 183.81 L 208.70 183.81 Q 210.42 183.81 211.32 183.98 Q 212.59 184.19 213.44 184.78 Q 214.29 185.38 214.82 186.45 Q 215.34 187.52 215.34 188.78 Q 215.34 190.98 213.94 192.50 Q 212.54 194.02 208.90 194.02 L 204.50 194.02 L 204.50 201.00 L 202.23 201.00 z M 204.50 191.98 L 208.93 191.98 Q 211.14 191.98 212.07 191.16 Q 213.00 190.34 213.00 188.86 Q 213.00 187.78 212.45 187.02 Q 211.90 186.25 211.01 186.00 Q 210.43 185.84 208.89 185.84 L 204.50 185.84 L 204.50 191.98 z M 217.18 194.78 Q 217.18 191.31 219.10 189.66 Q 220.71 188.27 223.02 188.27 Q 225.58 188.27 227.21 189.95 Q 228.83 191.64 228.83 194.59 Q 228.83 197.00 228.11 198.38 Q 227.39 199.75 226.02 200.52 Q 224.64 201.28 223.02 201.28 Q 220.39 201.28 218.79 199.60 Q 217.18 197.92 217.18 194.78 z M 219.35 194.78 Q 219.35 197.17 220.39 198.36 Q 221.43 199.55 223.02 199.55 Q 224.58 199.55 225.63 198.35 Q 226.68 197.16 226.68 194.70 Q 226.68 192.39 225.62 191.20 Q 224.57 190.02 223.02 190.02 Q 221.43 190.02 220.39 191.20 Q 219.35 192.39 219.35 194.78 z M 231.32 186.25 L 231.32 183.81 L 233.43 183.81 L 233.43 186.25 L 231.32 186.25 z M 231.32 201.00 L 231.32 188.55 L 233.43 188.55 L 233.43 201.00 L 231.32 201.00 z M 236.64 201.00 L 236.64 188.55 L 238.54 188.55 L 238.54 190.33 Q 239.92 188.27 242.50 188.27 Q 243.62 188.27 244.57 188.67 Q 245.51 189.08 245.98 189.73 Q 246.45 190.39 246.64 191.30 Q 246.76 191.88 246.76 193.34 L 246.76 201.00 L 244.65 201.00 L 244.65 193.42 Q 244.65 192.14 244.40 191.50 Q 244.15 190.86 243.53 190.48 Q 242.90 190.09 242.06 190.09 Q 240.71 190.09 239.73 190.95 Q 238.75 191.81 238.75 194.20 L 238.75 201.00 L 236.64 201.00 z M 254.59 199.11 L 254.91 200.97 Q 254.02 201.17 253.31 201.17 Q 252.16 201.17 251.52 200.80 Q 250.89 200.44 250.63 199.84 Q 250.38 199.25 250.38 197.36 L 250.38 190.19 L 248.83 190.19 L 248.83 188.55 L 250.38 188.55 L 250.38 185.47 L 252.47 184.20 L 252.47 188.55 L 254.59 188.55 L 254.59 190.19 L 252.47 190.19 L 252.47 197.47 Q 252.47 198.38 252.59 198.63 Q 252.70 198.89 252.95 199.04 Q 253.20 199.19 253.67 199.19 Q 254.02 199.19 254.59 199.11 z M 255.81 197.28 L 257.90 196.95 Q 258.07 198.20 258.88 198.88 Q 259.68 199.55 261.12 199.55 Q 262.57 199.55 263.28 198.95 Q 263.98 198.36 263.98 197.56 Q 263.98 196.84 263.36 196.44 Q 262.93 196.16 261.20 195.72 Q 258.89 195.14 257.99 194.71 Q 257.09 194.28 256.63 193.52 Q 256.17 192.77 256.17 191.86 Q 256.17 191.03 256.55 190.32 Q 256.93 189.61 257.59 189.14 Q 258.07 188.78 258.93 188.52 Q 259.78 188.27 260.75 188.27 Q 262.21 188.27 263.32 188.69 Q 264.43 189.11 264.96 189.84 Q 265.48 190.56 265.68 191.77 L 263.62 192.05 Q 263.48 191.08 262.81 190.54 Q 262.14 190.00 260.90 190.00 Q 259.45 190.00 258.82 190.48 Q 258.20 190.97 258.20 191.61 Q 258.20 192.02 258.46 192.34 Q 258.71 192.69 259.28 192.91 Q 259.59 193.03 261.14 193.45 Q 263.37 194.05 264.25 194.43 Q 265.14 194.81 265.64 195.54 Q 266.15 196.27 266.15 197.34 Q 266.15 198.39 265.54 199.33 Q 264.92 200.27 263.76 200.77 Q 262.61 201.28 261.14 201.28 Q 258.71 201.28 257.44 200.27 Q 256.17 199.27 255.81 197.28 z"/>
-<title>Button button1</title>
-<desc>button1</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip59 -->
-</g> <!-- transform -->
-</g><!-- layer0 -->
-</g> <!-- default stroke -->
-
-
-<!-- IMAGE2 ELEVATION ****************************************************** -->
-<g stroke-linejoin="miter" stroke-dashoffset="0.0000" stroke-dasharray="none" stroke-width="1.0000" stroke-miterlimit="10.000" stroke-linecap="square" transform="translate(0,-480)">
-<g id="misc">
-</g><!-- misc -->
-<g id="layer0">
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip4dde95ec-fb9c-4e3e-b731-1baefe706c76">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip1)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 1223.5 286.00 L 1223.5 307.00 C 1223.5 308.38 1224.6 309.50 1226.0 309.50 L 1247.0 309.50 C 1248.4 309.50 1249.5 308.38 1249.5 307.00 L 1249.5 286.00 C 1249.5 284.62 1248.4 283.50 1247.0 283.50 L 1226.0 283.50 C 1224.6 283.50 1223.5 284.62 1223.5 286.00 z"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip1 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip8a99866b-e585-4ffa-8662-c31c3cd6692e">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip2)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#ffffff">
-  <path d="M 1224.0 286.50 L 1224.0 305.50 C 1224.0 306.88 1225.1 308.00 1226.5 308.00 L 1245.5 308.00 C 1246.9 308.00 1248.0 306.88 1248.0 305.50 L 1248.0 286.50 C 1248.0 285.12 1246.9 284.00 1245.5 284.00 L 1226.5 284.00 C 1225.1 284.00 1224.0 285.12 1224.0 286.50 z"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip2 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipd50457c3-75a3-451f-9ed7-4cad760859c9">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip3)">
-<g stroke-linejoin="round" stroke-width="4.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#444444">
-  <path d="M 1228.5 298.50 L 1233.5 303.50"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip3 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip79880c43-0e45-4e72-b8e6-0b0bda667efe">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip4)">
-<g stroke-linejoin="round" stroke-width="4.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#444444">
-  <path d="M 1233.5 303.50 L 1243.5 289.50"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip4 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip25e52f64-b075-43f3-a279-6ccd16d655e5">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip5)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 1262.2 303.00 L 1262.2 292.89 L 1258.4 292.89 L 1258.4 291.55 L 1267.5 291.55 L 1267.5 292.89 L 1263.7 292.89 L 1263.7 303.00 L 1262.2 303.00 z M 1268.3 298.84 Q 1268.3 296.55 1269.6 295.44 Q 1270.7 294.52 1272.2 294.52 Q 1273.9 294.52 1275.0 295.63 Q 1276.1 296.75 1276.1 298.73 Q 1276.1 300.33 1275.6 301.25 Q 1275.1 302.17 1274.2 302.68 Q 1273.3 303.19 1272.2 303.19 Q 1270.5 303.19 1269.4 302.07 Q 1268.3 300.95 1268.3 298.84 z M 1269.8 298.84 Q 1269.8 300.44 1270.5 301.23 Q 1271.1 302.03 1272.2 302.03 Q 1273.2 302.03 1273.9 301.23 Q 1274.6 300.44 1274.6 298.80 Q 1274.6 297.27 1273.9 296.47 Q 1273.2 295.67 1272.2 295.67 Q 1271.1 295.67 1270.5 296.46 Q 1269.8 297.25 1269.8 298.84 z M 1277.5 303.69 L 1278.8 303.89 Q 1278.9 304.53 1279.3 304.81 Q 1279.8 305.20 1280.8 305.20 Q 1281.7 305.20 1282.2 304.81 Q 1282.8 304.42 1283.0 303.72 Q 1283.1 303.30 1283.1 301.91 Q 1282.2 303.00 1280.8 303.00 Q 1279.1 303.00 1278.1 301.77 Q 1277.2 300.53 1277.2 298.80 Q 1277.2 297.61 1277.6 296.61 Q 1278.0 295.61 1278.9 295.06 Q 1279.7 294.52 1280.8 294.52 Q 1282.2 294.52 1283.2 295.70 L 1283.2 294.70 L 1284.5 294.70 L 1284.5 301.88 Q 1284.5 303.81 1284.1 304.62 Q 1283.7 305.44 1282.9 305.91 Q 1282.0 306.38 1280.8 306.38 Q 1279.3 306.38 1278.4 305.70 Q 1277.4 305.03 1277.5 303.69 z M 1278.6 298.70 Q 1278.6 300.33 1279.3 301.08 Q 1279.9 301.83 1280.9 301.83 Q 1281.9 301.83 1282.5 301.09 Q 1283.2 300.34 1283.2 298.75 Q 1283.2 297.22 1282.5 296.45 Q 1281.8 295.67 1280.9 295.67 Q 1280.0 295.67 1279.3 296.44 Q 1278.6 297.20 1278.6 298.70 z M 1286.4 303.69 L 1287.7 303.89 Q 1287.8 304.53 1288.2 304.81 Q 1288.7 305.20 1289.6 305.20 Q 1290.6 305.20 1291.1 304.81 Q 1291.7 304.42 1291.9 303.72 Q 1292.0 303.30 1292.0 301.91 Q 1291.1 303.00 1289.7 303.00 Q 1288.0 303.00 1287.0 301.77 Q 1286.1 300.53 1286.1 298.80 Q 1286.1 297.61 1286.5 296.61 Q 1286.9 295.61 1287.8 295.06 Q 1288.6 294.52 1289.7 294.52 Q 1291.1 294.52 1292.1 295.70 L 1292.1 294.70 L 1293.4 294.70 L 1293.4 301.88 Q 1293.4 303.81 1293.0 304.62 Q 1292.6 305.44 1291.8 305.91 Q 1290.9 306.38 1289.6 306.38 Q 1288.2 306.38 1287.2 305.70 Q 1286.3 305.03 1286.4 303.69 z M 1287.5 298.70 Q 1287.5 300.33 1288.2 301.08 Q 1288.8 301.83 1289.8 301.83 Q 1290.8 301.83 1291.4 301.09 Q 1292.1 300.34 1292.1 298.75 Q 1292.1 297.22 1291.4 296.45 Q 1290.7 295.67 1289.8 295.67 Q 1288.9 295.67 1288.2 296.44 Q 1287.5 297.20 1287.5 298.70 z M 1295.5 303.00 L 1295.5 291.55 L 1296.9 291.55 L 1296.9 303.00 L 1295.5 303.00 z M 1304.8 300.33 L 1306.2 300.50 Q 1305.9 301.78 1304.9 302.48 Q 1304.0 303.19 1302.6 303.19 Q 1300.7 303.19 1299.7 302.06 Q 1298.6 300.94 1298.6 298.92 Q 1298.6 296.83 1299.7 295.67 Q 1300.8 294.52 1302.5 294.52 Q 1304.1 294.52 1305.2 295.65 Q 1306.3 296.78 1306.3 298.83 Q 1306.3 298.95 1306.3 299.20 L 1300.1 299.20 Q 1300.1 300.58 1300.8 301.30 Q 1301.5 302.03 1302.6 302.03 Q 1303.4 302.03 1303.9 301.62 Q 1304.4 301.22 1304.8 300.33 z M 1300.1 298.05 L 1304.8 298.05 Q 1304.7 297.00 1304.2 296.48 Q 1303.6 295.67 1302.5 295.67 Q 1301.5 295.67 1300.9 296.32 Q 1300.2 296.97 1300.1 298.05 z M 1312.6 303.00 L 1312.6 291.55 L 1320.9 291.55 L 1320.9 292.89 L 1314.1 292.89 L 1314.1 296.41 L 1320.5 296.41 L 1320.5 297.75 L 1314.1 297.75 L 1314.1 301.64 L 1321.2 301.64 L 1321.2 303.00 L 1312.6 303.00 z M 1322.2 303.00 L 1325.2 298.69 L 1322.4 294.70 L 1324.1 294.70 L 1325.4 296.64 Q 1325.8 297.20 1326.0 297.58 Q 1326.3 297.06 1326.6 296.66 L 1328.0 294.70 L 1329.7 294.70 L 1326.8 298.61 L 1329.9 303.00 L 1328.2 303.00 L 1326.5 300.42 L 1326.0 299.72 L 1323.9 303.00 L 1322.2 303.00 z M 1331.1 306.19 L 1331.1 294.70 L 1332.4 294.70 L 1332.4 295.78 Q 1332.8 295.14 1333.4 294.83 Q 1334.0 294.52 1334.8 294.52 Q 1335.9 294.52 1336.7 295.06 Q 1337.5 295.61 1337.9 296.60 Q 1338.3 297.59 1338.3 298.78 Q 1338.3 300.06 1337.8 301.08 Q 1337.4 302.09 1336.5 302.64 Q 1335.6 303.19 1334.7 303.19 Q 1334.0 303.19 1333.4 302.89 Q 1332.9 302.59 1332.5 302.14 L 1332.5 306.19 L 1331.1 306.19 z M 1332.4 298.89 Q 1332.4 300.50 1333.0 301.27 Q 1333.7 302.03 1334.6 302.03 Q 1335.5 302.03 1336.2 301.23 Q 1336.9 300.44 1336.9 298.78 Q 1336.9 297.19 1336.2 296.40 Q 1335.6 295.61 1334.6 295.61 Q 1333.8 295.61 1333.1 296.45 Q 1332.4 297.30 1332.4 298.89 z M 1339.5 298.84 Q 1339.5 296.55 1340.8 295.44 Q 1341.8 294.52 1343.4 294.52 Q 1345.1 294.52 1346.2 295.63 Q 1347.2 296.75 1347.2 298.73 Q 1347.2 300.33 1346.8 301.25 Q 1346.3 302.17 1345.4 302.68 Q 1344.5 303.19 1343.4 303.19 Q 1341.6 303.19 1340.5 302.07 Q 1339.5 300.95 1339.5 298.84 z M 1340.9 298.84 Q 1340.9 300.44 1341.6 301.23 Q 1342.3 302.03 1343.4 302.03 Q 1344.4 302.03 1345.1 301.23 Q 1345.8 300.44 1345.8 298.80 Q 1345.8 297.27 1345.1 296.47 Q 1344.4 295.67 1343.4 295.67 Q 1342.3 295.67 1341.6 296.46 Q 1340.9 297.25 1340.9 298.84 z M 1348.9 303.00 L 1348.9 294.70 L 1350.1 294.70 L 1350.1 295.95 Q 1350.6 295.08 1351.0 294.80 Q 1351.4 294.52 1351.9 294.52 Q 1352.6 294.52 1353.4 294.97 L 1352.9 296.27 Q 1352.4 295.97 1351.9 295.97 Q 1351.4 295.97 1351.0 296.24 Q 1350.7 296.52 1350.5 297.02 Q 1350.3 297.77 1350.3 298.66 L 1350.3 303.00 L 1348.9 303.00 z M 1357.3 301.73 L 1357.5 302.98 Q 1356.9 303.11 1356.4 303.11 Q 1355.7 303.11 1355.2 302.87 Q 1354.8 302.62 1354.6 302.23 Q 1354.5 301.83 1354.5 300.56 L 1354.5 295.80 L 1353.4 295.80 L 1353.4 294.70 L 1354.5 294.70 L 1354.5 292.64 L 1355.9 291.80 L 1355.9 294.70 L 1357.3 294.70 L 1357.3 295.80 L 1355.9 295.80 L 1355.9 300.64 Q 1355.9 301.25 1356.0 301.42 Q 1356.0 301.59 1356.2 301.70 Q 1356.4 301.80 1356.7 301.80 Q 1356.9 301.80 1357.3 301.73 z M 1363.3 303.00 L 1363.3 291.55 L 1371.6 291.55 L 1371.6 292.89 L 1364.8 292.89 L 1364.8 296.41 L 1371.2 296.41 L 1371.2 297.75 L 1364.8 297.75 L 1364.8 301.64 L 1371.9 301.64 L 1371.9 303.00 L 1363.3 303.00 z M 1379.2 303.00 L 1379.2 301.95 Q 1378.4 303.19 1376.9 303.19 Q 1375.9 303.19 1375.0 302.64 Q 1374.2 302.09 1373.7 301.11 Q 1373.3 300.12 1373.3 298.86 Q 1373.3 297.61 1373.7 296.60 Q 1374.1 295.59 1374.9 295.05 Q 1375.8 294.52 1376.8 294.52 Q 1377.5 294.52 1378.1 294.83 Q 1378.7 295.14 1379.1 295.66 L 1379.1 291.55 L 1380.5 291.55 L 1380.5 303.00 L 1379.2 303.00 z M 1374.7 298.86 Q 1374.7 300.45 1375.4 301.24 Q 1376.1 302.03 1377.0 302.03 Q 1377.9 302.03 1378.5 301.27 Q 1379.2 300.52 1379.2 298.97 Q 1379.2 297.27 1378.5 296.47 Q 1377.9 295.67 1376.9 295.67 Q 1376.0 295.67 1375.4 296.44 Q 1374.7 297.20 1374.7 298.86 z M 1382.4 303.69 L 1383.8 303.89 Q 1383.9 304.53 1384.3 304.81 Q 1384.8 305.20 1385.7 305.20 Q 1386.7 305.20 1387.2 304.81 Q 1387.7 304.42 1387.9 303.72 Q 1388.0 303.30 1388.0 301.91 Q 1387.1 303.00 1385.7 303.00 Q 1384.0 303.00 1383.1 301.77 Q 1382.1 300.53 1382.1 298.80 Q 1382.1 297.61 1382.6 296.61 Q 1383.0 295.61 1383.8 295.06 Q 1384.6 294.52 1385.7 294.52 Q 1387.2 294.52 1388.2 295.70 L 1388.2 294.70 L 1389.5 294.70 L 1389.5 301.88 Q 1389.5 303.81 1389.1 304.62 Q 1388.7 305.44 1387.8 305.91 Q 1387.0 306.38 1385.7 306.38 Q 1384.2 306.38 1383.3 305.70 Q 1382.4 305.03 1382.4 303.69 z M 1383.6 298.70 Q 1383.6 300.33 1384.2 301.08 Q 1384.9 301.83 1385.9 301.83 Q 1386.8 301.83 1387.5 301.09 Q 1388.1 300.34 1388.1 298.75 Q 1388.1 297.22 1387.5 296.45 Q 1386.8 295.67 1385.8 295.67 Q 1384.9 295.67 1384.2 296.44 Q 1383.6 297.20 1383.6 298.70 z M 1397.3 300.33 L 1398.7 300.50 Q 1398.4 301.78 1397.4 302.48 Q 1396.5 303.19 1395.1 303.19 Q 1393.2 303.19 1392.2 302.06 Q 1391.1 300.94 1391.1 298.92 Q 1391.1 296.83 1392.2 295.67 Q 1393.3 294.52 1395.0 294.52 Q 1396.6 294.52 1397.7 295.65 Q 1398.8 296.78 1398.8 298.83 Q 1398.8 298.95 1398.8 299.20 L 1392.6 299.20 Q 1392.6 300.58 1393.3 301.30 Q 1394.0 302.03 1395.1 302.03 Q 1395.9 302.03 1396.4 301.62 Q 1396.9 301.22 1397.3 300.33 z M 1392.6 298.05 L 1397.3 298.05 Q 1397.2 297.00 1396.7 296.48 Q 1396.1 295.67 1395.0 295.67 Q 1394.0 295.67 1393.4 296.32 Q 1392.7 296.97 1392.6 298.05 z M 1399.9 300.52 L 1401.3 300.30 Q 1401.4 301.14 1402.0 301.59 Q 1402.5 302.03 1403.5 302.03 Q 1404.4 302.03 1404.9 301.63 Q 1405.4 301.23 1405.4 300.70 Q 1405.4 300.23 1405.0 299.95 Q 1404.7 299.77 1403.5 299.48 Q 1402.0 299.09 1401.4 298.80 Q 1400.8 298.52 1400.5 298.02 Q 1400.2 297.52 1400.2 296.91 Q 1400.2 296.34 1400.4 295.88 Q 1400.7 295.41 1401.1 295.09 Q 1401.4 294.84 1402.0 294.68 Q 1402.6 294.52 1403.2 294.52 Q 1404.2 294.52 1404.9 294.80 Q 1405.7 295.08 1406.0 295.55 Q 1406.4 296.03 1406.5 296.84 L 1405.1 297.03 Q 1405.0 296.39 1404.6 296.03 Q 1404.1 295.67 1403.3 295.67 Q 1402.3 295.67 1401.9 295.99 Q 1401.5 296.31 1401.5 296.73 Q 1401.5 297.02 1401.7 297.23 Q 1401.9 297.45 1402.2 297.61 Q 1402.4 297.69 1403.5 297.97 Q 1405.0 298.36 1405.5 298.62 Q 1406.1 298.88 1406.5 299.36 Q 1406.8 299.84 1406.8 300.56 Q 1406.8 301.27 1406.4 301.88 Q 1406.0 302.50 1405.2 302.84 Q 1404.4 303.19 1403.5 303.19 Q 1401.8 303.19 1401.0 302.52 Q 1400.2 301.84 1399.9 300.52 z"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip5 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipdb473069-d965-4bd7-a7ff-0afc65198508">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip6)">
-<g fill-opacity=".24706" fill-rule="evenodd" stroke="none" fill="#a0a0a0">
-  <path d="M 659.77 291.78 L 778.91 194.50 L 768.63 408.48 L 656.42 520.69 z"/>
-<title>Quadrilateral pane_{poly}</title>
-<desc>Quadrilateral pane_{poly}: Polygon pane_D, pane_C, pane_B, pane_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip6 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip77a5d110-8ce3-40d2-913b-be0c5d43eb6d">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip7)">
-<g fill-opacity="1.0000" fill-rule="evenodd" stroke="none" fill="#a0a0a0">
-  <path d="M 309.94 449.06 L 505.68 305.15 L 899.65 412.44 L 742.53 590.97 z"/>
-<title>Quadrilateral base_{poly}</title>
-<desc>Quadrilateral base_{poly}: Polygon base_D, base_C, base_B, base_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip7 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipa080828f-f67c-4c5a-8669-c3978c0310dc">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip8)">
-<g fill-opacity="1.0000" fill-rule="evenodd" stroke="none" fill="#808080">
-  <path d="M 469.18 405.99 L 500.70 381.17 L 549.14 395.36 L 518.31 420.84 z"/>
-<title>Quadrilateral shad_{poly}</title>
-<desc>Quadrilateral shad_{poly}: Polygon shad_E, shad_F, shad_B, shad_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip8 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip53f9513d-b3ca-4be0-9f3b-66970852103a">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip9)">
-<g fill-opacity="1.0000" fill-rule="evenodd" stroke="none" fill="#0099ff">
-  <path d="M 496.52 252.85 L 546.79 265.86 L 547.75 318.85 L 516.16 343.13 L 465.92 328.98 L 463.66 275.62 z"/>
-<title>Hexagon cube_{poly}</title>
-<desc>Hexagon cube_{poly}: Polygon cube_G, cube_C, cube_B, cube_A, cube_E, cube_H</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip9 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip001f7369-37d4-426b-a9d8-5f90dc77e663">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip10)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 704.87 340.12 L 733.91 314.32"/>
-<title>Segment proj_a</title>
-<desc>Segment proj_a: Segment proj_D, proj_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip10 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipf97102aa-fc8d-4508-aeb0-83caba6c57a3">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip11)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 733.91 314.32 L 731.91 369.12"/>
-<title>Segment proj_b</title>
-<desc>Segment proj_b: Segment proj_C, proj_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip11 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip0fb15310-9565-4a33-a5be-b33406749118">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip12)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 703.30 395.85 L 731.91 369.12"/>
-<title>Segment proj_c</title>
-<desc>Segment proj_c: Segment proj_A, proj_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip12 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip9149d0a9-5303-4c77-a372-eefe2f9d9440">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip13)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 703.30 395.85 L 704.87 340.12"/>
-<title>Segment proj_d</title>
-<desc>Segment proj_d: Segment proj_A, proj_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip13 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipd7a1a119-f25c-4c8c-892a-ce829ba17134">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip14)">
-<g stroke-linejoin="round" stroke-width="2.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 289.52 156.18 L 929.52 156.18"/>
-<title>Segment edge_a</title>
-<desc>Segment edge_a: Segment edge_A, Export_2</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip14 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip5a88c5ec-09d1-497b-8586-dcfacf71e863">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip15)">
-<g stroke-linejoin="round" stroke-width="2.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 929.52 156.18 L 929.52 636.18"/>
-<title>Segment edge_b</title>
-<desc>Segment edge_b: Segment Export_2, edge_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip15 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipa9507918-d11c-4fd1-9eb3-90961388b896">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip16)">
-<g stroke-linejoin="round" stroke-width="2.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 929.52 636.18 L 289.52 636.18"/>
-<title>Segment edge_c</title>
-<desc>Segment edge_c: Segment edge_B, Export_1</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip16 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipe732cd63-44e3-4229-91dd-5aec55ee3be7">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip17)">
-<g stroke-linejoin="round" stroke-width="2.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 289.52 636.18 L 289.52 156.18"/>
-<title>Segment edge_d</title>
-<desc>Segment edge_d: Segment Export_1, edge_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip17 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip88583e40-0347-41c1-9142-b1a509c63d8a">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip18)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 659.77 291.78 L 778.91 194.50"/>
-<title>Segment pane_a</title>
-<desc>Segment pane_a: Segment pane_D, pane_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip18 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip0afc4deb-a9fe-4dbc-8a1a-60901ef48cc5">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip19)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 778.91 194.50 L 768.63 408.48"/>
-<title>Segment pane_b</title>
-<desc>Segment pane_b: Segment pane_C, pane_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip19 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip44789ee5-a41e-4dfc-a5a2-de7053afec9e">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip20)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 768.63 408.48 L 656.42 520.69"/>
-<title>Segment pane_c</title>
-<desc>Segment pane_c: Segment pane_B, pane_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip20 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip8656dfde-374f-4b3f-852d-488c0cde8364">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip21)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 656.42 520.69 L 659.77 291.78"/>
-<title>Segment pane_d</title>
-<desc>Segment pane_d: Segment pane_A, pane_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip21 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip98531861-bf73-4dc6-849c-9d2cdc0e7cf0">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip22)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 463.66 275.62 L 496.52 252.85"/>
-<title>Segment cube_r</title>
-<desc>Segment cube_r: Segment cube_H, cube_G</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip22 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip2c582589-98df-4388-8d1d-659c201cc72c">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip23)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 496.52 252.85 L 546.79 265.86"/>
-<title>Segment cube_s</title>
-<desc>Segment cube_s: Segment cube_G, cube_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip23 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipdb390743-dcda-4706-8aca-201f9f95d5c9">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip24)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 546.79 265.86 L 547.75 318.85"/>
-<title>Segment cube_t</title>
-<desc>Segment cube_t: Segment cube_C, cube_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip24 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipa9271676-d249-489f-b57a-394c85eb51e7">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip25)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 547.75 318.85 L 516.16 343.13"/>
-<title>Segment cube_u</title>
-<desc>Segment cube_u: Segment cube_B, cube_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip25 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip4a77d494-d793-4c6c-ae7b-441e523f0c35">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip26)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 516.16 343.13 L 465.92 328.98"/>
-<title>Segment cube_m</title>
-<desc>Segment cube_m: Segment cube_A, cube_E</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip26 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip7124e6d3-a796-44aa-80cb-645a681dc3eb">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip27)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 465.92 328.98 L 463.66 275.62"/>
-<title>Segment cube_n</title>
-<desc>Segment cube_n: Segment cube_E, cube_H</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip27 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip20ccb621-7864-476c-99a2-5ae2658e8bef">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip28)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 463.66 275.62 L 514.67 289.26"/>
-<title>Segment cube_o</title>
-<desc>Segment cube_o: Segment cube_H, cube_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip28 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipf1212f7f-52bb-4082-a8a6-5f8a4df46c5d">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip29)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 514.67 289.26 L 546.79 265.86"/>
-<title>Segment cube_p</title>
-<desc>Segment cube_p: Segment cube_D, cube_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip29 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipe78b6412-2196-4242-b683-b210ef67cd26">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip30)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 514.67 289.26 L 516.16 343.13"/>
-<title>Segment cube_q</title>
-<desc>Segment cube_q: Segment cube_D, cube_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip30 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip7839f857-9cdc-44b4-93a1-24929c8d5277">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip31)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 469.18 405.99 L 500.70 381.17"/>
-<title>Segment shad_m</title>
-<desc>Segment shad_m: Segment shad_E, shad_F</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip31 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipae387fe9-ee94-4e44-babc-4886853aea31">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip32)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 500.70 381.17 L 549.14 395.36"/>
-<title>Segment shad_n</title>
-<desc>Segment shad_n: Segment shad_F, shad_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip32 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipd9fe9f9c-42f2-4ce1-9819-738bb186d65f">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip33)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 549.14 395.36 L 518.31 420.84"/>
-<title>Segment shad_o</title>
-<desc>Segment shad_o: Segment shad_B, shad_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip33 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipa6573476-7b72-4656-88f4-f7d63d37f88b">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip34)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 518.31 420.84 L 469.18 405.99"/>
-<title>Segment shad_p</title>
-<desc>Segment shad_p: Segment shad_A, shad_E</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip34 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip1dcfe9ee-c3b7-433f-9323-203ca277e209">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip35)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 471.23 330.47 L 309.94 449.06"/>
-<title>Segment base_a</title>
-<desc>Segment base_a: Segment base_E, base_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip35 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip03a4b03d-947d-44bd-b043-43cb55790122">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip36)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 309.94 449.06 L 742.53 590.97"/>
-<title>Segment base_b</title>
-<desc>Segment base_b: Segment base_D, base_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip36 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipa50bfdb7-dd4e-4c6e-945b-59a01f2f7bc4">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip37)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 742.53 590.97 L 899.65 412.44"/>
-<title>Segment base_c</title>
-<desc>Segment base_c: Segment base_A, base_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip37 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipb36e09e6-1926-4946-89ba-2cd261633ed0">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip38)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 899.65 412.44 L 547.71 316.60"/>
-<title>Segment base_d</title>
-<desc>Segment base_d: Segment base_B, base_F</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip38 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip99afced7-9e97-4433-941c-3cfbfc0e3ca3">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip39)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 514.67 289.26 L 704.87 340.12"/>
-<title>Segment vect_j</title>
-<desc>Segment vect_j: Segment cube_D, proj_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip39 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip9038e89d-318d-42ef-a6c6-c88c9ca2dd8d">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip40)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 546.79 265.86 L 733.91 314.32"/>
-<title>Segment vect_k</title>
-<desc>Segment vect_k: Segment cube_C, proj_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip40 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip9e26c249-fdb9-44d6-a72b-52fd46fc028e">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip41)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 516.16 343.13 L 703.30 395.85"/>
-<title>Segment vect_l</title>
-<desc>Segment vect_l: Segment cube_A, proj_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip41 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipab90a193-d988-4e16-b772-d80b28fa1d64">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip42)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 547.75 318.85 L 731.91 369.12"/>
-<title>Segment vect_m</title>
-<desc>Segment vect_m: Segment cube_B, proj_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip42 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipedd0f227-53de-4564-b869-f2d4f9f0fdef">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip43)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 322.66 204.00 L 325.05 192.55 L 333.55 192.55 L 333.14 194.45 L 327.02 194.45 L 326.47 197.06 L 332.39 197.06 L 332.00 198.97 L 326.06 198.97 L 325.34 202.08 L 332.02 202.08 L 331.61 204.00 L 322.66 204.00 z M 333.39 204.00 L 335.80 192.55 L 338.14 192.55 L 336.16 202.08 L 341.98 202.08 L 341.58 204.00 L 333.39 204.00 z M 343.10 204.00 L 345.49 192.55 L 353.99 192.55 L 353.59 194.45 L 347.46 194.45 L 346.91 197.06 L 352.84 197.06 L 352.45 198.97 L 346.51 198.97 L 345.79 202.08 L 352.46 202.08 L 352.05 204.00 L 343.10 204.00 z M 359.51 204.00 L 356.99 204.00 L 354.93 192.55 L 357.29 192.55 L 358.74 201.20 L 363.48 192.55 L 365.82 192.55 L 359.51 204.00 z M 371.95 201.47 L 367.41 201.47 L 366.04 204.00 L 363.60 204.00 L 370.09 192.55 L 372.71 192.55 L 374.57 204.00 L 372.34 204.00 L 371.95 201.47 z M 371.66 199.56 L 370.99 194.95 L 368.23 199.56 L 371.66 199.56 z M 380.98 204.00 L 378.62 204.00 L 380.62 194.45 L 377.27 194.45 L 377.67 192.55 L 386.69 192.55 L 386.30 194.45 L 382.98 194.45 L 380.98 204.00 z M 385.68 204.00 L 388.07 192.55 L 390.43 192.55 L 388.04 204.00 L 385.68 204.00 z M 390.97 199.50 Q 390.97 198.48 391.27 197.36 Q 391.67 195.86 392.48 194.75 Q 393.30 193.64 394.54 192.99 Q 395.78 192.34 397.38 192.34 Q 399.50 192.34 400.80 193.66 Q 402.11 194.98 402.11 197.17 Q 402.11 198.98 401.26 200.68 Q 400.41 202.38 398.95 203.29 Q 397.48 204.20 395.64 204.20 Q 394.05 204.20 392.96 203.48 Q 391.88 202.75 391.42 201.67 Q 390.97 200.59 390.97 199.50 z M 393.30 199.45 Q 393.30 200.64 394.02 201.44 Q 394.73 202.23 395.91 202.23 Q 396.86 202.23 397.73 201.60 Q 398.61 200.97 399.19 199.70 Q 399.77 198.42 399.77 197.20 Q 399.77 195.86 399.04 195.09 Q 398.31 194.31 397.19 194.31 Q 395.45 194.31 394.38 195.92 Q 393.30 197.53 393.30 199.45 z M 411.82 204.00 L 409.63 204.00 L 406.54 196.30 L 404.93 204.00 L 402.73 204.00 L 405.12 192.55 L 407.32 192.55 L 410.43 200.20 L 412.02 192.55 L 414.21 192.55 L 411.82 204.00 z"/>
-<title>ELEVATION&#xa;(ORTHOGRAPHIC)</title>
-<desc>text12 = “ELEVATION&#xa;(ORTHOGRAPHIC)”</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip43 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipf1dd8dd2-27ce-4aec-abd5-7bccc8d78af2">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip44)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 325.84 231.38 L 324.31 231.38 Q 323.67 229.88 323.37 228.34 Q 323.06 226.81 323.06 225.55 Q 323.06 223.95 323.57 222.34 Q 324.08 220.73 325.14 219.08 Q 325.80 218.02 327.27 216.34 L 328.97 216.34 Q 327.48 218.09 326.67 219.63 Q 325.86 221.17 325.46 222.98 Q 325.06 224.80 325.06 226.53 Q 325.06 227.70 325.24 228.82 Q 325.42 229.94 325.84 231.38 z M 328.73 223.50 Q 328.73 222.48 329.03 221.36 Q 329.44 219.86 330.25 218.75 Q 331.06 217.64 332.30 216.99 Q 333.55 216.34 335.14 216.34 Q 337.27 216.34 338.57 217.66 Q 339.88 218.98 339.88 221.17 Q 339.88 222.98 339.02 224.68 Q 338.17 226.38 336.71 227.29 Q 335.25 228.20 333.41 228.20 Q 331.81 228.20 330.73 227.48 Q 329.64 226.75 329.19 225.67 Q 328.73 224.59 328.73 223.50 z M 331.06 223.45 Q 331.06 224.64 331.78 225.44 Q 332.50 226.23 333.67 226.23 Q 334.62 226.23 335.50 225.60 Q 336.38 224.97 336.95 223.70 Q 337.53 222.42 337.53 221.20 Q 337.53 219.86 336.80 219.09 Q 336.08 218.31 334.95 218.31 Q 333.22 218.31 332.14 219.92 Q 331.06 221.53 331.06 223.45 z M 342.84 228.00 L 340.48 228.00 L 342.88 216.55 L 347.96 216.55 Q 349.27 216.55 350.01 216.81 Q 350.74 217.08 351.19 217.80 Q 351.63 218.52 351.63 219.55 Q 351.63 221.00 350.76 221.95 Q 349.88 222.91 348.12 223.12 Q 348.57 223.53 348.96 224.20 Q 349.76 225.55 350.73 228.00 L 348.20 228.00 Q 347.88 227.03 346.99 224.97 Q 346.51 223.86 345.96 223.48 Q 345.63 223.25 344.79 223.25 L 343.84 223.25 L 342.84 228.00 z M 344.20 221.53 L 345.45 221.53 Q 347.34 221.53 347.96 221.30 Q 348.59 221.08 348.94 220.59 Q 349.29 220.11 349.29 219.58 Q 349.29 218.95 348.77 218.64 Q 348.46 218.45 347.43 218.45 L 344.84 218.45 L 344.20 221.53 z M 356.97 228.00 L 354.61 228.00 L 356.61 218.45 L 353.25 218.45 L 353.66 216.55 L 362.67 216.55 L 362.28 218.45 L 358.97 218.45 L 356.97 228.00 z M 369.66 222.88 L 365.23 222.88 L 364.16 228.00 L 361.80 228.00 L 364.20 216.55 L 366.55 216.55 L 365.63 220.97 L 370.05 220.97 L 370.99 216.55 L 373.34 216.55 L 370.95 228.00 L 368.59 228.00 L 369.66 222.88 z M 374.06 223.50 Q 374.06 222.48 374.36 221.36 Q 374.77 219.86 375.58 218.75 Q 376.39 217.64 377.63 216.99 Q 378.88 216.34 380.47 216.34 Q 382.59 216.34 383.90 217.66 Q 385.20 218.98 385.20 221.17 Q 385.20 222.98 384.35 224.68 Q 383.50 226.38 382.04 227.29 Q 380.58 228.20 378.73 228.20 Q 377.14 228.20 376.05 227.48 Q 374.97 226.75 374.52 225.67 Q 374.06 224.59 374.06 223.50 z M 376.39 223.45 Q 376.39 224.64 377.11 225.44 Q 377.83 226.23 379.00 226.23 Q 379.95 226.23 380.83 225.60 Q 381.70 224.97 382.28 223.70 Q 382.86 222.42 382.86 221.20 Q 382.86 219.86 382.13 219.09 Q 381.41 218.31 380.28 218.31 Q 378.55 218.31 377.47 219.92 Q 376.39 221.53 376.39 223.45 z M 392.13 221.88 L 397.26 221.88 L 396.23 226.80 Q 395.32 227.38 394.01 227.79 Q 392.70 228.20 391.32 228.20 Q 389.20 228.20 388.07 227.23 Q 386.52 225.92 386.52 223.42 Q 386.52 221.75 387.18 220.22 Q 387.98 218.38 389.45 217.36 Q 390.91 216.34 392.90 216.34 Q 394.88 216.34 396.09 217.27 Q 397.29 218.19 397.68 219.95 L 395.48 220.20 Q 395.20 219.23 394.55 218.74 Q 393.90 218.25 392.93 218.25 Q 391.79 218.25 390.84 218.84 Q 389.88 219.44 389.34 220.68 Q 388.80 221.92 388.80 223.39 Q 388.80 224.84 389.46 225.53 Q 390.12 226.22 391.38 226.22 Q 392.13 226.22 392.93 226.01 Q 393.73 225.80 394.30 225.50 L 394.66 223.80 L 391.74 223.80 L 392.13 221.88 z M 400.61 228.00 L 398.25 228.00 L 400.66 216.55 L 405.73 216.55 Q 407.05 216.55 407.78 216.81 Q 408.52 217.08 408.96 217.80 Q 409.41 218.52 409.41 219.55 Q 409.41 221.00 408.53 221.95 Q 407.66 222.91 405.89 223.12 Q 406.34 223.53 406.73 224.20 Q 407.53 225.55 408.50 228.00 L 405.97 228.00 Q 405.66 227.03 404.77 224.97 Q 404.28 223.86 403.73 223.48 Q 403.41 223.25 402.56 223.25 L 401.61 223.25 L 400.61 228.00 z M 401.97 221.53 L 403.22 221.53 Q 405.11 221.53 405.73 221.30 Q 406.36 221.08 406.71 220.59 Q 407.06 220.11 407.06 219.58 Q 407.06 218.95 406.55 218.64 Q 406.23 218.45 405.20 218.45 L 402.61 218.45 L 401.97 221.53 z M 417.26 225.47 L 412.73 225.47 L 411.35 228.00 L 408.91 228.00 L 415.40 216.55 L 418.02 216.55 L 419.88 228.00 L 417.65 228.00 L 417.26 225.47 z M 416.98 223.56 L 416.30 218.95 L 413.54 223.56 L 416.98 223.56 z M 423.67 228.00 L 421.31 228.00 L 423.70 216.55 L 428.36 216.55 Q 429.61 216.55 430.33 216.84 Q 431.05 217.12 431.47 217.80 Q 431.89 218.48 431.89 219.42 Q 431.89 220.28 431.55 221.10 Q 431.22 221.92 430.73 222.41 Q 430.25 222.91 429.69 223.16 Q 429.12 223.42 428.17 223.55 Q 427.61 223.62 426.09 223.62 L 424.58 223.62 L 423.67 228.00 z M 424.97 221.73 L 425.70 221.73 Q 427.56 221.73 428.19 221.50 Q 428.81 221.27 429.17 220.75 Q 429.53 220.23 429.53 219.61 Q 429.53 219.20 429.35 218.94 Q 429.17 218.67 428.84 218.55 Q 428.50 218.42 427.36 218.42 L 425.67 218.42 L 424.97 221.73 z M 439.89 222.88 L 435.45 222.88 L 434.39 228.00 L 432.03 228.00 L 434.42 216.55 L 436.78 216.55 L 435.86 220.97 L 440.28 220.97 L 441.22 216.55 L 443.56 216.55 L 441.17 228.00 L 438.81 228.00 L 439.89 222.88 z M 443.45 228.00 L 445.84 216.55 L 448.20 216.55 L 445.80 228.00 L 443.45 228.00 z M 456.28 223.88 L 458.66 224.23 Q 457.97 226.16 456.58 227.18 Q 455.19 228.20 453.31 228.20 Q 451.22 228.20 450.03 226.94 Q 448.84 225.67 448.84 223.27 Q 448.84 221.31 449.64 219.69 Q 450.44 218.06 451.84 217.20 Q 453.25 216.34 454.91 216.34 Q 456.77 216.34 457.91 217.34 Q 459.06 218.34 459.27 220.06 L 457.00 220.28 Q 456.81 219.28 456.28 218.83 Q 455.75 218.38 454.86 218.38 Q 453.88 218.38 453.03 218.97 Q 452.19 219.56 451.68 220.83 Q 451.17 222.09 451.17 223.34 Q 451.17 224.72 451.83 225.47 Q 452.48 226.22 453.47 226.22 Q 454.39 226.22 455.15 225.62 Q 455.91 225.03 456.28 223.88 z M 460.77 216.34 L 462.29 216.34 Q 462.93 217.83 463.24 219.36 Q 463.55 220.89 463.55 222.16 Q 463.55 223.75 463.04 225.36 Q 462.52 226.97 461.48 228.64 Q 460.80 229.70 459.34 231.38 L 457.63 231.38 Q 459.12 229.62 459.93 228.09 Q 460.74 226.55 461.14 224.73 Q 461.54 222.92 461.54 221.17 Q 461.54 220.00 461.37 218.89 Q 461.20 217.78 460.77 216.34 z"/>
-<title>ELEVATION&#xa;(ORTHOGRAPHIC)</title>
-<desc>text12 = “ELEVATION&#xa;(ORTHOGRAPHIC)”</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip44 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipc78bca3c-f0ca-42af-8fd6-9599fc6c7c9c">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip45)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#ffffff">
-  <path d="M 1215.0 165.00 L 1215.0 196.00 C 1215.0 198.21 1216.8 200.00 1219.0 200.00 L 1458.0 200.00 C 1460.2 200.00 1462.0 198.21 1462.0 196.00 L 1462.0 165.00 C 1462.0 162.79 1460.2 161.00 1458.0 161.00 L 1219.0 161.00 C 1216.8 161.00 1215.0 162.79 1215.0 165.00 z"/>
-<title>Button button1</title>
-<desc>button1</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip45 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip5f305c93-aaf7-4524-ae5a-da601dee7db2">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip46)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 1215.5 165.50 L 1215.5 196.50 C 1215.5 198.71 1217.3 200.50 1219.5 200.50 L 1458.5 200.50 C 1460.7 200.50 1462.5 198.71 1462.5 196.50 L 1462.5 165.50 C 1462.5 163.29 1460.7 161.50 1458.5 161.50 L 1219.5 161.50 C 1217.3 161.50 1215.5 163.29 1215.5 165.50 z"/>
-<title>Button button1</title>
-<desc>button1</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip46 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipf67da375-b541-4f23-8431-d59ad824ca5a">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip47)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 1238.1 183.97 L 1240.4 184.55 Q 1239.7 187.34 1237.8 188.82 Q 1236.0 190.30 1233.3 190.30 Q 1230.5 190.30 1228.8 189.16 Q 1227.0 188.03 1226.1 185.88 Q 1225.2 183.73 1225.2 181.28 Q 1225.2 178.59 1226.2 176.59 Q 1227.2 174.59 1229.1 173.56 Q 1231.0 172.53 1233.3 172.53 Q 1235.9 172.53 1237.6 173.84 Q 1239.4 175.16 1240.1 177.53 L 1237.9 178.06 Q 1237.2 176.19 1236.1 175.33 Q 1235.0 174.47 1233.3 174.47 Q 1231.3 174.47 1230.0 175.42 Q 1228.6 176.38 1228.1 177.97 Q 1227.5 179.56 1227.5 181.27 Q 1227.5 183.45 1228.2 185.09 Q 1228.8 186.73 1230.2 187.54 Q 1231.5 188.34 1233.1 188.34 Q 1235.0 188.34 1236.3 187.24 Q 1237.6 186.14 1238.1 183.97 z M 1242.9 190.00 L 1242.9 172.81 L 1245.0 172.81 L 1245.0 190.00 L 1242.9 190.00 z M 1248.3 175.25 L 1248.3 172.81 L 1250.4 172.81 L 1250.4 175.25 L 1248.3 175.25 z M 1248.3 190.00 L 1248.3 177.55 L 1250.4 177.55 L 1250.4 190.00 L 1248.3 190.00 z M 1261.7 185.44 L 1263.8 185.70 Q 1263.4 187.86 1262.0 189.07 Q 1260.6 190.28 1258.6 190.28 Q 1256.0 190.28 1254.5 188.61 Q 1252.9 186.94 1252.9 183.83 Q 1252.9 181.81 1253.6 180.30 Q 1254.3 178.78 1255.6 178.02 Q 1257.0 177.27 1258.6 177.27 Q 1260.6 177.27 1261.9 178.30 Q 1263.2 179.33 1263.6 181.20 L 1261.5 181.53 Q 1261.2 180.27 1260.5 179.63 Q 1259.7 179.00 1258.7 179.00 Q 1257.1 179.00 1256.1 180.15 Q 1255.1 181.30 1255.1 183.77 Q 1255.1 186.27 1256.1 187.41 Q 1257.0 188.55 1258.6 188.55 Q 1259.8 188.55 1260.6 187.78 Q 1261.5 187.02 1261.7 185.44 z M 1265.6 190.00 L 1265.6 172.81 L 1267.7 172.81 L 1267.7 182.61 L 1272.7 177.55 L 1275.4 177.55 L 1270.7 182.17 L 1275.9 190.00 L 1273.3 190.00 L 1269.2 183.64 L 1267.7 185.06 L 1267.7 190.00 L 1265.6 190.00 z M 1288.9 190.00 L 1288.9 174.84 L 1283.2 174.84 L 1283.2 172.81 L 1296.9 172.81 L 1296.9 174.84 L 1291.2 174.84 L 1291.2 190.00 L 1288.9 190.00 z M 1301.2 190.00 L 1297.4 177.55 L 1299.6 177.55 L 1301.6 184.73 L 1302.3 187.41 Q 1302.3 187.20 1302.9 184.84 L 1304.9 177.55 L 1307.1 177.55 L 1308.9 184.77 L 1309.6 187.16 L 1310.3 184.75 L 1312.4 177.55 L 1314.5 177.55 L 1310.6 190.00 L 1308.4 190.00 L 1306.4 182.55 L 1305.9 180.42 L 1303.4 190.00 L 1301.2 190.00 z M 1316.2 175.25 L 1316.2 172.81 L 1318.4 172.81 L 1318.4 175.25 L 1316.2 175.25 z M 1316.2 190.00 L 1316.2 177.55 L 1318.4 177.55 L 1318.4 190.00 L 1316.2 190.00 z M 1329.7 185.44 L 1331.8 185.70 Q 1331.4 187.86 1330.0 189.07 Q 1328.6 190.28 1326.6 190.28 Q 1324.0 190.28 1322.5 188.61 Q 1320.9 186.94 1320.9 183.83 Q 1320.9 181.81 1321.6 180.30 Q 1322.3 178.78 1323.6 178.02 Q 1325.0 177.27 1326.6 177.27 Q 1328.6 177.27 1329.9 178.30 Q 1331.2 179.33 1331.6 181.20 L 1329.5 181.53 Q 1329.2 180.27 1328.5 179.63 Q 1327.7 179.00 1326.7 179.00 Q 1325.1 179.00 1324.1 180.15 Q 1323.1 181.30 1323.1 183.77 Q 1323.1 186.27 1324.1 187.41 Q 1325.0 188.55 1326.6 188.55 Q 1327.8 188.55 1328.6 187.78 Q 1329.5 187.02 1329.7 185.44 z M 1342.1 185.98 L 1344.3 186.27 Q 1343.8 188.17 1342.4 189.23 Q 1341.0 190.28 1338.8 190.28 Q 1336.1 190.28 1334.5 188.60 Q 1332.9 186.92 1332.9 183.88 Q 1332.9 180.73 1334.5 179.00 Q 1336.1 177.27 1338.7 177.27 Q 1341.2 177.27 1342.8 178.97 Q 1344.3 180.67 1344.3 183.75 Q 1344.3 183.94 1344.3 184.31 L 1335.1 184.31 Q 1335.2 186.36 1336.2 187.45 Q 1337.3 188.55 1338.8 188.55 Q 1340.0 188.55 1340.8 187.94 Q 1341.6 187.33 1342.1 185.98 z M 1335.2 182.58 L 1342.1 182.58 Q 1342.0 181.02 1341.3 180.22 Q 1340.3 179.00 1338.7 179.00 Q 1337.3 179.00 1336.3 179.98 Q 1335.3 180.95 1335.2 182.58 z M 1358.2 188.11 L 1358.5 189.97 Q 1357.6 190.17 1356.9 190.17 Q 1355.8 190.17 1355.1 189.80 Q 1354.5 189.44 1354.2 188.84 Q 1354.0 188.25 1354.0 186.36 L 1354.0 179.19 L 1352.4 179.19 L 1352.4 177.55 L 1354.0 177.55 L 1354.0 174.47 L 1356.1 173.20 L 1356.1 177.55 L 1358.2 177.55 L 1358.2 179.19 L 1356.1 179.19 L 1356.1 186.47 Q 1356.1 187.38 1356.2 187.63 Q 1356.3 187.89 1356.6 188.04 Q 1356.8 188.19 1357.3 188.19 Q 1357.6 188.19 1358.2 188.11 z M 1359.5 183.78 Q 1359.5 180.31 1361.4 178.66 Q 1363.0 177.27 1365.3 177.27 Q 1367.9 177.27 1369.5 178.95 Q 1371.1 180.64 1371.1 183.59 Q 1371.1 186.00 1370.4 187.38 Q 1369.7 188.75 1368.3 189.52 Q 1366.9 190.28 1365.3 190.28 Q 1362.7 190.28 1361.1 188.60 Q 1359.5 186.92 1359.5 183.78 z M 1361.6 183.78 Q 1361.6 186.17 1362.7 187.36 Q 1363.7 188.55 1365.3 188.55 Q 1366.9 188.55 1367.9 187.35 Q 1369.0 186.16 1369.0 183.70 Q 1369.0 181.39 1367.9 180.20 Q 1366.9 179.02 1365.3 179.02 Q 1363.7 179.02 1362.7 180.20 Q 1361.6 181.39 1361.6 183.78 z M 1380.6 190.00 L 1380.6 172.81 L 1388.2 172.81 Q 1390.5 172.81 1391.7 173.28 Q 1392.9 173.75 1393.6 174.92 Q 1394.3 176.09 1394.3 177.50 Q 1394.3 179.33 1393.1 180.59 Q 1391.9 181.84 1389.5 182.19 Q 1390.4 182.61 1390.8 183.03 Q 1391.8 183.95 1392.7 185.33 L 1395.7 190.00 L 1392.9 190.00 L 1390.6 186.42 Q 1389.6 184.88 1388.9 184.05 Q 1388.3 183.23 1387.8 182.91 Q 1387.3 182.58 1386.8 182.45 Q 1386.4 182.38 1385.5 182.38 L 1382.8 182.38 L 1382.8 190.00 L 1380.6 190.00 z M 1382.8 180.41 L 1387.7 180.41 Q 1389.3 180.41 1390.2 180.08 Q 1391.0 179.75 1391.5 179.05 Q 1392.0 178.34 1392.0 177.50 Q 1392.0 176.28 1391.1 175.50 Q 1390.2 174.72 1388.3 174.72 L 1382.8 174.72 L 1382.8 180.41 z M 1406.1 185.98 L 1408.3 186.27 Q 1407.8 188.17 1406.4 189.23 Q 1405.0 190.28 1402.8 190.28 Q 1400.1 190.28 1398.5 188.60 Q 1396.9 186.92 1396.9 183.88 Q 1396.9 180.73 1398.5 179.00 Q 1400.1 177.27 1402.7 177.27 Q 1405.2 177.27 1406.8 178.97 Q 1408.4 180.67 1408.4 183.75 Q 1408.4 183.94 1408.4 184.31 L 1399.1 184.31 Q 1399.2 186.36 1400.2 187.45 Q 1401.3 188.55 1402.8 188.55 Q 1404.0 188.55 1404.8 187.94 Q 1405.6 187.33 1406.1 185.98 z M 1399.2 182.58 L 1406.1 182.58 Q 1406.0 181.02 1405.3 180.22 Q 1404.3 179.00 1402.7 179.00 Q 1401.3 179.00 1400.3 179.98 Q 1399.3 180.95 1399.2 182.58 z M 1410.1 186.28 L 1412.2 185.95 Q 1412.4 187.20 1413.2 187.88 Q 1414.0 188.55 1415.4 188.55 Q 1416.9 188.55 1417.6 187.95 Q 1418.3 187.36 1418.3 186.56 Q 1418.3 185.84 1417.6 185.44 Q 1417.2 185.16 1415.5 184.72 Q 1413.2 184.14 1412.3 183.71 Q 1411.4 183.28 1410.9 182.52 Q 1410.5 181.77 1410.5 180.86 Q 1410.5 180.03 1410.8 179.32 Q 1411.2 178.61 1411.9 178.14 Q 1412.4 177.78 1413.2 177.52 Q 1414.1 177.27 1415.0 177.27 Q 1416.5 177.27 1417.6 177.69 Q 1418.7 178.11 1419.2 178.84 Q 1419.8 179.56 1420.0 180.77 L 1417.9 181.05 Q 1417.8 180.08 1417.1 179.54 Q 1416.4 179.00 1415.2 179.00 Q 1413.7 179.00 1413.1 179.48 Q 1412.5 179.97 1412.5 180.61 Q 1412.5 181.02 1412.8 181.34 Q 1413.0 181.69 1413.6 181.91 Q 1413.9 182.03 1415.4 182.45 Q 1417.7 183.05 1418.5 183.43 Q 1419.4 183.81 1419.9 184.54 Q 1420.4 185.27 1420.4 186.34 Q 1420.4 187.39 1419.8 188.33 Q 1419.2 189.27 1418.1 189.77 Q 1416.9 190.28 1415.4 190.28 Q 1413.0 190.28 1411.7 189.27 Q 1410.5 188.27 1410.1 186.28 z M 1423.0 175.25 L 1423.0 172.81 L 1425.1 172.81 L 1425.1 175.25 L 1423.0 175.25 z M 1423.0 190.00 L 1423.0 177.55 L 1425.1 177.55 L 1425.1 190.00 L 1423.0 190.00 z M 1427.2 190.00 L 1427.2 188.28 L 1435.1 179.19 Q 1433.7 179.27 1432.7 179.27 L 1427.6 179.27 L 1427.6 177.55 L 1437.8 177.55 L 1437.8 178.95 L 1431.1 186.84 L 1429.8 188.28 Q 1431.2 188.19 1432.4 188.19 L 1438.2 188.19 L 1438.2 190.00 L 1427.2 190.00 z M 1448.8 185.98 L 1451.0 186.27 Q 1450.5 188.17 1449.1 189.23 Q 1447.7 190.28 1445.5 190.28 Q 1442.8 190.28 1441.2 188.60 Q 1439.6 186.92 1439.6 183.88 Q 1439.6 180.73 1441.2 179.00 Q 1442.8 177.27 1445.4 177.27 Q 1447.9 177.27 1449.5 178.97 Q 1451.1 180.67 1451.1 183.75 Q 1451.1 183.94 1451.0 184.31 L 1441.8 184.31 Q 1441.9 186.36 1442.9 187.45 Q 1444.0 188.55 1445.5 188.55 Q 1446.7 188.55 1447.5 187.94 Q 1448.3 187.33 1448.8 185.98 z M 1441.9 182.58 L 1448.8 182.58 Q 1448.7 181.02 1448.0 180.22 Q 1447.0 179.00 1445.4 179.00 Q 1444.0 179.00 1443.0 179.98 Q 1442.0 180.95 1441.9 182.58 z"/>
-<title>Button button1</title>
-<desc>button1</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip47 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clip46fa667c-2676-4504-9f17-4b4918e03207">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip48)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#ffffff">
-  <path d="M 1213.0 87.000 L 1213.0 118.00 C 1213.0 120.21 1214.8 122.00 1217.0 122.00 L 1428.0 122.00 C 1430.2 122.00 1432.0 120.21 1432.0 118.00 L 1432.0 87.000 C 1432.0 84.791 1430.2 83.000 1428.0 83.000 L 1217.0 83.000 C 1214.8 83.000 1213.0 84.791 1213.0 87.000 z"/>
-<title>Button button2</title>
-<desc>button2</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip48 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipaae765d0-4418-4c40-9751-767cabebc610">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip49)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 1213.5 87.500 L 1213.5 118.50 C 1213.5 120.71 1215.3 122.50 1217.5 122.50 L 1428.5 122.50 C 1430.7 122.50 1432.5 120.71 1432.5 118.50 L 1432.5 87.500 C 1432.5 85.291 1430.7 83.500 1428.5 83.500 L 1217.5 83.500 C 1215.3 83.500 1213.5 85.291 1213.5 87.500 z"/>
-<title>Button button2</title>
-<desc>button2</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip49 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -289.52, -156.18)">
-<clipPath id="clipf3f0da8c-8044-4ff6-bb4a-3376eae2929b">
-  <path d="M 289.52 156.18 L 289.52 638.18 L 931.52 638.18 L 931.52 156.18 z"/>
-</clipPath>
-<g clip-path="url(#clip50)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 1236.1 105.97 L 1238.4 106.55 Q 1237.7 109.34 1235.8 110.82 Q 1234.0 112.30 1231.3 112.30 Q 1228.5 112.30 1226.8 111.16 Q 1225.0 110.03 1224.1 107.88 Q 1223.2 105.73 1223.2 103.28 Q 1223.2 100.59 1224.2 98.594 Q 1225.2 96.594 1227.1 95.562 Q 1229.0 94.531 1231.3 94.531 Q 1233.9 94.531 1235.6 95.844 Q 1237.4 97.156 1238.1 99.531 L 1235.9 100.06 Q 1235.2 98.188 1234.1 97.328 Q 1233.0 96.469 1231.3 96.469 Q 1229.3 96.469 1228.0 97.422 Q 1226.6 98.375 1226.1 99.969 Q 1225.5 101.56 1225.5 103.27 Q 1225.5 105.45 1226.2 107.09 Q 1226.8 108.73 1228.2 109.54 Q 1229.5 110.34 1231.1 110.34 Q 1233.0 110.34 1234.3 109.24 Q 1235.6 108.14 1236.1 105.97 z M 1240.9 112.00 L 1240.9 94.812 L 1243.0 94.812 L 1243.0 112.00 L 1240.9 112.00 z M 1246.3 97.250 L 1246.3 94.812 L 1248.4 94.812 L 1248.4 97.250 L 1246.3 97.250 z M 1246.3 112.00 L 1246.3 99.547 L 1248.4 99.547 L 1248.4 112.00 L 1246.3 112.00 z M 1259.7 107.44 L 1261.8 107.70 Q 1261.4 109.86 1260.0 111.07 Q 1258.6 112.28 1256.6 112.28 Q 1254.0 112.28 1252.5 110.61 Q 1250.9 108.94 1250.9 105.83 Q 1250.9 103.81 1251.6 102.30 Q 1252.3 100.78 1253.6 100.02 Q 1255.0 99.266 1256.6 99.266 Q 1258.6 99.266 1259.9 100.30 Q 1261.2 101.33 1261.6 103.20 L 1259.5 103.53 Q 1259.2 102.27 1258.5 101.63 Q 1257.7 101.00 1256.7 101.00 Q 1255.1 101.00 1254.1 102.15 Q 1253.1 103.30 1253.1 105.77 Q 1253.1 108.27 1254.1 109.41 Q 1255.0 110.55 1256.6 110.55 Q 1257.8 110.55 1258.6 109.78 Q 1259.5 109.02 1259.7 107.44 z M 1263.6 112.00 L 1263.6 94.812 L 1265.7 94.812 L 1265.7 104.61 L 1270.7 99.547 L 1273.4 99.547 L 1268.7 104.17 L 1273.9 112.00 L 1271.3 112.00 L 1267.2 105.64 L 1265.7 107.06 L 1265.7 112.00 L 1263.6 112.00 z M 1286.9 110.11 L 1287.2 111.97 Q 1286.3 112.17 1285.6 112.17 Q 1284.4 112.17 1283.8 111.80 Q 1283.1 111.44 1282.9 110.84 Q 1282.6 110.25 1282.6 108.36 L 1282.6 101.19 L 1281.1 101.19 L 1281.1 99.547 L 1282.6 99.547 L 1282.6 96.469 L 1284.7 95.203 L 1284.7 99.547 L 1286.9 99.547 L 1286.9 101.19 L 1284.7 101.19 L 1284.7 108.47 Q 1284.7 109.38 1284.8 109.63 Q 1285.0 109.89 1285.2 110.04 Q 1285.5 110.19 1285.9 110.19 Q 1286.3 110.19 1286.9 110.11 z M 1288.1 105.78 Q 1288.1 102.31 1290.1 100.66 Q 1291.7 99.266 1294.0 99.266 Q 1296.5 99.266 1298.2 100.95 Q 1299.8 102.64 1299.8 105.59 Q 1299.8 108.00 1299.1 109.38 Q 1298.3 110.75 1297.0 111.52 Q 1295.6 112.28 1294.0 112.28 Q 1291.3 112.28 1289.7 110.60 Q 1288.1 108.92 1288.1 105.78 z M 1290.3 105.78 Q 1290.3 108.17 1291.3 109.36 Q 1292.4 110.55 1294.0 110.55 Q 1295.5 110.55 1296.6 109.35 Q 1297.6 108.16 1297.6 105.70 Q 1297.6 103.39 1296.6 102.20 Q 1295.5 101.02 1294.0 101.02 Q 1292.4 101.02 1291.3 102.20 Q 1290.3 103.39 1290.3 105.78 z M 1309.2 112.00 L 1309.2 94.812 L 1315.7 94.812 Q 1317.4 94.812 1318.3 94.984 Q 1319.6 95.188 1320.4 95.781 Q 1321.3 96.375 1321.8 97.445 Q 1322.3 98.516 1322.3 99.781 Q 1322.3 101.98 1320.9 103.50 Q 1319.5 105.02 1315.9 105.02 L 1311.5 105.02 L 1311.5 112.00 L 1309.2 112.00 z M 1311.5 102.98 L 1315.9 102.98 Q 1318.1 102.98 1319.0 102.16 Q 1320.0 101.34 1320.0 99.859 Q 1320.0 98.781 1319.4 98.016 Q 1318.9 97.250 1318.0 97.000 Q 1317.4 96.844 1315.9 96.844 L 1311.5 96.844 L 1311.5 102.98 z M 1324.9 112.00 L 1324.9 94.812 L 1327.0 94.812 L 1327.0 112.00 L 1324.9 112.00 z M 1329.5 105.78 Q 1329.5 102.31 1331.4 100.66 Q 1333.0 99.266 1335.3 99.266 Q 1337.9 99.266 1339.5 100.95 Q 1341.1 102.64 1341.1 105.59 Q 1341.1 108.00 1340.4 109.38 Q 1339.7 110.75 1338.3 111.52 Q 1337.0 112.28 1335.3 112.28 Q 1332.7 112.28 1331.1 110.60 Q 1329.5 108.92 1329.5 105.78 z M 1331.7 105.78 Q 1331.7 108.17 1332.7 109.36 Q 1333.7 110.55 1335.3 110.55 Q 1336.9 110.55 1337.9 109.35 Q 1339.0 108.16 1339.0 105.70 Q 1339.0 103.39 1337.9 102.20 Q 1336.9 101.02 1335.3 101.02 Q 1333.7 101.02 1332.7 102.20 Q 1331.7 103.39 1331.7 105.78 z M 1348.2 110.11 L 1348.5 111.97 Q 1347.6 112.17 1346.9 112.17 Q 1345.8 112.17 1345.2 111.80 Q 1344.5 111.44 1344.3 110.84 Q 1344.0 110.25 1344.0 108.36 L 1344.0 101.19 L 1342.5 101.19 L 1342.5 99.547 L 1344.0 99.547 L 1344.0 96.469 L 1346.1 95.203 L 1346.1 99.547 L 1348.2 99.547 L 1348.2 101.19 L 1346.1 101.19 L 1346.1 108.47 Q 1346.1 109.38 1346.2 109.63 Q 1346.3 109.89 1346.6 110.04 Q 1346.8 110.19 1347.3 110.19 Q 1347.6 110.19 1348.2 110.11 z M 1357.2 112.00 L 1357.2 94.812 L 1363.7 94.812 Q 1365.4 94.812 1366.3 94.984 Q 1367.6 95.188 1368.4 95.781 Q 1369.3 96.375 1369.8 97.445 Q 1370.3 98.516 1370.3 99.781 Q 1370.3 101.98 1368.9 103.50 Q 1367.5 105.02 1363.9 105.02 L 1359.5 105.02 L 1359.5 112.00 L 1357.2 112.00 z M 1359.5 102.98 L 1363.9 102.98 Q 1366.1 102.98 1367.1 102.16 Q 1368.0 101.34 1368.0 99.859 Q 1368.0 98.781 1367.4 98.016 Q 1366.9 97.250 1366.0 97.000 Q 1365.4 96.844 1363.9 96.844 L 1359.5 96.844 L 1359.5 102.98 z M 1372.2 105.78 Q 1372.2 102.31 1374.1 100.66 Q 1375.7 99.266 1378.0 99.266 Q 1380.6 99.266 1382.2 100.95 Q 1383.8 102.64 1383.8 105.59 Q 1383.8 108.00 1383.1 109.38 Q 1382.4 110.75 1381.0 111.52 Q 1379.6 112.28 1378.0 112.28 Q 1375.4 112.28 1373.8 110.60 Q 1372.2 108.92 1372.2 105.78 z M 1374.3 105.78 Q 1374.3 108.17 1375.4 109.36 Q 1376.4 110.55 1378.0 110.55 Q 1379.6 110.55 1380.6 109.35 Q 1381.7 108.16 1381.7 105.70 Q 1381.7 103.39 1380.6 102.20 Q 1379.6 101.02 1378.0 101.02 Q 1376.4 101.02 1375.4 102.20 Q 1374.3 103.39 1374.3 105.78 z M 1386.3 97.250 L 1386.3 94.812 L 1388.4 94.812 L 1388.4 97.250 L 1386.3 97.250 z M 1386.3 112.00 L 1386.3 99.547 L 1388.4 99.547 L 1388.4 112.00 L 1386.3 112.00 z M 1391.6 112.00 L 1391.6 99.547 L 1393.5 99.547 L 1393.5 101.33 Q 1394.9 99.266 1397.5 99.266 Q 1398.6 99.266 1399.6 99.672 Q 1400.5 100.08 1401.0 100.73 Q 1401.4 101.39 1401.6 102.30 Q 1401.8 102.88 1401.8 104.34 L 1401.8 112.00 L 1399.7 112.00 L 1399.7 104.42 Q 1399.7 103.14 1399.4 102.50 Q 1399.2 101.86 1398.5 101.48 Q 1397.9 101.09 1397.1 101.09 Q 1395.7 101.09 1394.7 101.95 Q 1393.7 102.81 1393.7 105.20 L 1393.7 112.00 L 1391.6 112.00 z M 1409.6 110.11 L 1409.9 111.97 Q 1409.0 112.17 1408.3 112.17 Q 1407.2 112.17 1406.5 111.80 Q 1405.9 111.44 1405.6 110.84 Q 1405.4 110.25 1405.4 108.36 L 1405.4 101.19 L 1403.8 101.19 L 1403.8 99.547 L 1405.4 99.547 L 1405.4 96.469 L 1407.5 95.203 L 1407.5 99.547 L 1409.6 99.547 L 1409.6 101.19 L 1407.5 101.19 L 1407.5 108.47 Q 1407.5 109.38 1407.6 109.63 Q 1407.7 109.89 1408.0 110.04 Q 1408.2 110.19 1408.7 110.19 Q 1409.0 110.19 1409.6 110.11 z M 1410.8 108.28 L 1412.9 107.95 Q 1413.1 109.20 1413.9 109.88 Q 1414.7 110.55 1416.1 110.55 Q 1417.6 110.55 1418.3 109.95 Q 1419.0 109.36 1419.0 108.56 Q 1419.0 107.84 1418.4 107.44 Q 1417.9 107.16 1416.2 106.72 Q 1413.9 106.14 1413.0 105.71 Q 1412.1 105.28 1411.6 104.52 Q 1411.2 103.77 1411.2 102.86 Q 1411.2 102.03 1411.6 101.32 Q 1411.9 100.61 1412.6 100.14 Q 1413.1 99.781 1413.9 99.523 Q 1414.8 99.266 1415.7 99.266 Q 1417.2 99.266 1418.3 99.688 Q 1419.4 100.11 1420.0 100.84 Q 1420.5 101.56 1420.7 102.77 L 1418.6 103.05 Q 1418.5 102.08 1417.8 101.54 Q 1417.1 101.00 1415.9 101.00 Q 1414.4 101.00 1413.8 101.48 Q 1413.2 101.97 1413.2 102.61 Q 1413.2 103.02 1413.5 103.34 Q 1413.7 103.69 1414.3 103.91 Q 1414.6 104.03 1416.1 104.45 Q 1418.4 105.05 1419.3 105.43 Q 1420.1 105.81 1420.6 106.54 Q 1421.2 107.27 1421.2 108.34 Q 1421.2 109.39 1420.5 110.33 Q 1419.9 111.27 1418.8 111.77 Q 1417.6 112.28 1416.1 112.28 Q 1413.7 112.28 1412.4 111.27 Q 1411.2 110.27 1410.8 108.28 z"/>
-<title>Button button2</title>
-<desc>button2</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip50 -->
-</g> <!-- transform -->
-</g><!-- layer0 -->
-</g> <!-- default stroke -->
-
-
-<!-- IMAGE3 ISOMETRIC **************************************************** -->
-<g stroke-linejoin="miter" stroke-dashoffset="0.0000" stroke-dasharray="none" stroke-width="1.0000" stroke-miterlimit="10.000" stroke-linecap="square" transform="translate(-640,0)">
-<g id="misc">
-</g><!-- misc -->
-<g id="layer0">
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip30bef249-ea47-4657-a6e6-6044277e837a">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip1)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 32.500 255.00 L 32.500 276.00 C 32.500 277.38 33.619 278.50 35.000 278.50 L 56.000 278.50 C 57.381 278.50 58.500 277.38 58.500 276.00 L 58.500 255.00 C 58.500 253.62 57.381 252.50 56.000 252.50 L 35.000 252.50 C 33.619 252.50 32.500 253.62 32.500 255.00 z"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip1 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipcc46cdf2-6402-485a-a838-8df7a8e6c044">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip2)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#ffffff">
-  <path d="M 33.000 255.50 L 33.000 274.50 C 33.000 275.88 34.119 277.00 35.500 277.00 L 54.500 277.00 C 55.881 277.00 57.000 275.88 57.000 274.50 L 57.000 255.50 C 57.000 254.12 55.881 253.00 54.500 253.00 L 35.500 253.00 C 34.119 253.00 33.000 254.12 33.000 255.50 z"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip2 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip9c3dbbb0-4ca4-49e8-85d1-8e7880dbb004">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip3)">
-<g stroke-linejoin="round" stroke-width="4.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#444444">
-  <path d="M 37.500 267.50 L 42.500 272.50"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip3 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipe823dfbe-8777-4dca-bc5a-15c1c6021ec0">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip4)">
-<g stroke-linejoin="round" stroke-width="4.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#444444">
-  <path d="M 42.500 272.50 L 52.500 258.50"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip4 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip7e2352b4-ce13-40cd-8def-634336e85895">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip5)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 71.156 272.00 L 71.156 261.89 L 67.375 261.89 L 67.375 260.55 L 76.453 260.55 L 76.453 261.89 L 72.672 261.89 L 72.672 272.00 L 71.156 272.00 z M 77.305 267.84 Q 77.305 265.55 78.586 264.44 Q 79.664 263.52 81.195 263.52 Q 82.914 263.52 84.000 264.63 Q 85.086 265.75 85.086 267.73 Q 85.086 269.33 84.602 270.25 Q 84.117 271.17 83.203 271.68 Q 82.289 272.19 81.195 272.19 Q 79.461 272.19 78.383 271.07 Q 77.305 269.95 77.305 267.84 z M 78.758 267.84 Q 78.758 269.44 79.453 270.23 Q 80.148 271.03 81.195 271.03 Q 82.242 271.03 82.938 270.23 Q 83.633 269.44 83.633 267.80 Q 83.633 266.27 82.938 265.47 Q 82.242 264.67 81.195 264.67 Q 80.148 264.67 79.453 265.46 Q 78.758 266.25 78.758 267.84 z M 86.469 272.69 L 87.844 272.89 Q 87.922 273.53 88.312 273.81 Q 88.844 274.20 89.750 274.20 Q 90.719 274.20 91.250 273.81 Q 91.781 273.42 91.969 272.72 Q 92.078 272.30 92.078 270.91 Q 91.156 272.00 89.781 272.00 Q 88.062 272.00 87.125 270.77 Q 86.188 269.53 86.188 267.80 Q 86.188 266.61 86.617 265.61 Q 87.047 264.61 87.867 264.06 Q 88.688 263.52 89.781 263.52 Q 91.250 263.52 92.203 264.70 L 92.203 263.70 L 93.500 263.70 L 93.500 270.88 Q 93.500 272.81 93.109 273.62 Q 92.719 274.44 91.859 274.91 Q 91.000 275.38 89.750 275.38 Q 88.266 275.38 87.352 274.70 Q 86.438 274.03 86.469 272.69 z M 87.641 267.70 Q 87.641 269.33 88.289 270.08 Q 88.938 270.83 89.906 270.83 Q 90.875 270.83 91.531 270.09 Q 92.188 269.34 92.188 267.75 Q 92.188 266.22 91.516 265.45 Q 90.844 264.67 89.891 264.67 Q 88.953 264.67 88.297 265.44 Q 87.641 266.20 87.641 267.70 z M 95.367 272.69 L 96.742 272.89 Q 96.820 273.53 97.211 273.81 Q 97.742 274.20 98.648 274.20 Q 99.617 274.20 100.15 273.81 Q 100.68 273.42 100.87 272.72 Q 100.98 272.30 100.98 270.91 Q 100.05 272.00 98.680 272.00 Q 96.961 272.00 96.023 270.77 Q 95.086 269.53 95.086 267.80 Q 95.086 266.61 95.516 265.61 Q 95.945 264.61 96.766 264.06 Q 97.586 263.52 98.680 263.52 Q 100.15 263.52 101.10 264.70 L 101.10 263.70 L 102.40 263.70 L 102.40 270.88 Q 102.40 272.81 102.01 273.62 Q 101.62 274.44 100.76 274.91 Q 99.898 275.38 98.648 275.38 Q 97.164 275.38 96.250 274.70 Q 95.336 274.03 95.367 272.69 z M 96.539 267.70 Q 96.539 269.33 97.188 270.08 Q 97.836 270.83 98.805 270.83 Q 99.773 270.83 100.43 270.09 Q 101.09 269.34 101.09 267.75 Q 101.09 266.22 100.41 265.45 Q 99.742 264.67 98.789 264.67 Q 97.852 264.67 97.195 265.44 Q 96.539 266.20 96.539 267.70 z M 104.50 272.00 L 104.50 260.55 L 105.91 260.55 L 105.91 272.00 L 104.50 272.00 z M 113.76 269.33 L 115.21 269.50 Q 114.87 270.78 113.94 271.48 Q 113.01 272.19 111.57 272.19 Q 109.74 272.19 108.68 271.06 Q 107.62 269.94 107.62 267.92 Q 107.62 265.83 108.70 264.67 Q 109.77 263.52 111.49 263.52 Q 113.15 263.52 114.20 264.65 Q 115.26 265.78 115.26 267.83 Q 115.26 267.95 115.26 268.20 L 109.07 268.20 Q 109.15 269.58 109.84 270.30 Q 110.54 271.03 111.57 271.03 Q 112.35 271.03 112.90 270.62 Q 113.45 270.22 113.76 269.33 z M 109.15 267.05 L 113.77 267.05 Q 113.68 266.00 113.24 265.48 Q 112.57 264.67 111.51 264.67 Q 110.54 264.67 109.88 265.32 Q 109.21 265.97 109.15 267.05 z M 121.63 272.00 L 121.63 260.55 L 129.91 260.55 L 129.91 261.89 L 123.15 261.89 L 123.15 265.41 L 129.49 265.41 L 129.49 266.75 L 123.15 266.75 L 123.15 270.64 L 130.18 270.64 L 130.18 272.00 L 121.63 272.00 z M 131.16 272.00 L 134.20 267.69 L 131.38 263.70 L 133.15 263.70 L 134.41 265.64 Q 134.77 266.20 134.99 266.58 Q 135.34 266.06 135.63 265.66 L 137.02 263.70 L 138.71 263.70 L 135.84 267.61 L 138.93 272.00 L 137.20 272.00 L 135.49 269.42 L 135.04 268.72 L 132.87 272.00 L 131.16 272.00 z M 140.10 275.19 L 140.10 263.70 L 141.38 263.70 L 141.38 264.78 Q 141.84 264.14 142.41 263.83 Q 142.98 263.52 143.79 263.52 Q 144.85 263.52 145.66 264.06 Q 146.48 264.61 146.89 265.60 Q 147.30 266.59 147.30 267.78 Q 147.30 269.06 146.84 270.08 Q 146.38 271.09 145.52 271.64 Q 144.65 272.19 143.68 272.19 Q 142.98 272.19 142.42 271.89 Q 141.87 271.59 141.51 271.14 L 141.51 275.19 L 140.10 275.19 z M 141.37 267.89 Q 141.37 269.50 142.02 270.27 Q 142.66 271.03 143.59 271.03 Q 144.52 271.03 145.20 270.23 Q 145.87 269.44 145.87 267.78 Q 145.87 266.19 145.21 265.40 Q 144.55 264.61 143.65 264.61 Q 142.76 264.61 142.06 265.45 Q 141.37 266.30 141.37 267.89 z M 148.47 267.84 Q 148.47 265.55 149.75 264.44 Q 150.83 263.52 152.36 263.52 Q 154.08 263.52 155.16 264.63 Q 156.25 265.75 156.25 267.73 Q 156.25 269.33 155.77 270.25 Q 155.28 271.17 154.37 271.68 Q 153.45 272.19 152.36 272.19 Q 150.62 272.19 149.55 271.07 Q 148.47 269.95 148.47 267.84 z M 149.92 267.84 Q 149.92 269.44 150.62 270.23 Q 151.31 271.03 152.36 271.03 Q 153.41 271.03 154.10 270.23 Q 154.80 269.44 154.80 267.80 Q 154.80 266.27 154.10 265.47 Q 153.41 264.67 152.36 264.67 Q 151.31 264.67 150.62 265.46 Q 149.92 266.25 149.92 267.84 z M 157.88 272.00 L 157.88 263.70 L 159.15 263.70 L 159.15 264.95 Q 159.63 264.08 160.04 263.80 Q 160.45 263.52 160.95 263.52 Q 161.65 263.52 162.38 263.97 L 161.90 265.27 Q 161.38 264.97 160.87 264.97 Q 160.41 264.97 160.05 265.24 Q 159.68 265.52 159.52 266.02 Q 159.29 266.77 159.29 267.66 L 159.29 272.00 L 157.88 272.00 z M 166.29 270.73 L 166.49 271.98 Q 165.90 272.11 165.43 272.11 Q 164.66 272.11 164.24 271.87 Q 163.82 271.62 163.65 271.23 Q 163.48 270.83 163.48 269.56 L 163.48 264.80 L 162.45 264.80 L 162.45 263.70 L 163.48 263.70 L 163.48 261.64 L 164.88 260.80 L 164.88 263.70 L 166.29 263.70 L 166.29 264.80 L 164.88 264.80 L 164.88 269.64 Q 164.88 270.25 164.95 270.42 Q 165.02 270.59 165.20 270.70 Q 165.37 270.80 165.68 270.80 Q 165.91 270.80 166.29 270.73 z M 172.32 272.00 L 172.32 260.55 L 180.60 260.55 L 180.60 261.89 L 173.84 261.89 L 173.84 265.41 L 180.18 265.41 L 180.18 266.75 L 173.84 266.75 L 173.84 270.64 L 180.87 270.64 L 180.87 272.00 L 172.32 272.00 z M 188.16 272.00 L 188.16 270.95 Q 187.38 272.19 185.85 272.19 Q 184.85 272.19 184.02 271.64 Q 183.20 271.09 182.73 270.11 Q 182.27 269.12 182.27 267.86 Q 182.27 266.61 182.69 265.60 Q 183.10 264.59 183.93 264.05 Q 184.76 263.52 185.79 263.52 Q 186.54 263.52 187.12 263.83 Q 187.71 264.14 188.07 264.66 L 188.07 260.55 L 189.48 260.55 L 189.48 272.00 L 188.16 272.00 z M 183.73 267.86 Q 183.73 269.45 184.40 270.24 Q 185.07 271.03 185.98 271.03 Q 186.90 271.03 187.55 270.27 Q 188.20 269.52 188.20 267.97 Q 188.20 266.27 187.54 265.47 Q 186.88 264.67 185.91 264.67 Q 184.98 264.67 184.35 265.44 Q 183.73 266.20 183.73 267.86 z M 191.42 272.69 L 192.80 272.89 Q 192.88 273.53 193.27 273.81 Q 193.80 274.20 194.70 274.20 Q 195.67 274.20 196.20 273.81 Q 196.73 273.42 196.92 272.72 Q 197.03 272.30 197.03 270.91 Q 196.11 272.00 194.73 272.00 Q 193.02 272.00 192.08 270.77 Q 191.14 269.53 191.14 267.80 Q 191.14 266.61 191.57 265.61 Q 192.00 264.61 192.82 264.06 Q 193.64 263.52 194.73 263.52 Q 196.20 263.52 197.16 264.70 L 197.16 263.70 L 198.45 263.70 L 198.45 270.88 Q 198.45 272.81 198.06 273.62 Q 197.67 274.44 196.81 274.91 Q 195.95 275.38 194.70 275.38 Q 193.22 275.38 192.30 274.70 Q 191.39 274.03 191.42 272.69 z M 192.59 267.70 Q 192.59 269.33 193.24 270.08 Q 193.89 270.83 194.86 270.83 Q 195.83 270.83 196.48 270.09 Q 197.14 269.34 197.14 267.75 Q 197.14 266.22 196.47 265.45 Q 195.80 264.67 194.84 264.67 Q 193.91 264.67 193.25 265.44 Q 192.59 266.20 192.59 267.70 z M 206.26 269.33 L 207.71 269.50 Q 207.37 270.78 206.44 271.48 Q 205.51 272.19 204.07 272.19 Q 202.24 272.19 201.18 271.06 Q 200.12 269.94 200.12 267.92 Q 200.12 265.83 201.20 264.67 Q 202.27 263.52 203.99 263.52 Q 205.65 263.52 206.70 264.65 Q 207.76 265.78 207.76 267.83 Q 207.76 267.95 207.76 268.20 L 201.57 268.20 Q 201.65 269.58 202.34 270.30 Q 203.04 271.03 204.07 271.03 Q 204.85 271.03 205.40 270.62 Q 205.95 270.22 206.26 269.33 z M 201.65 267.05 L 206.27 267.05 Q 206.18 266.00 205.74 265.48 Q 205.07 264.67 204.01 264.67 Q 203.04 264.67 202.38 265.32 Q 201.71 265.97 201.65 267.05 z M 208.92 269.52 L 210.31 269.30 Q 210.42 270.14 210.96 270.59 Q 211.50 271.03 212.45 271.03 Q 213.42 271.03 213.89 270.63 Q 214.36 270.23 214.36 269.70 Q 214.36 269.23 213.95 268.95 Q 213.66 268.77 212.52 268.48 Q 210.97 268.09 210.37 267.80 Q 209.77 267.52 209.46 267.02 Q 209.16 266.52 209.16 265.91 Q 209.16 265.34 209.41 264.88 Q 209.66 264.41 210.09 264.09 Q 210.42 263.84 210.99 263.68 Q 211.56 263.52 212.20 263.52 Q 213.19 263.52 213.92 263.80 Q 214.66 264.08 215.01 264.55 Q 215.36 265.03 215.50 265.84 L 214.12 266.03 Q 214.03 265.39 213.58 265.03 Q 213.12 264.67 212.31 264.67 Q 211.34 264.67 210.93 264.99 Q 210.52 265.31 210.52 265.73 Q 210.52 266.02 210.69 266.23 Q 210.86 266.45 211.22 266.61 Q 211.44 266.69 212.47 266.97 Q 213.95 267.36 214.55 267.62 Q 215.14 267.88 215.48 268.36 Q 215.81 268.84 215.81 269.56 Q 215.81 270.27 215.40 270.88 Q 214.98 271.50 214.21 271.84 Q 213.44 272.19 212.47 272.19 Q 210.84 272.19 210.00 271.52 Q 209.16 270.84 208.92 269.52 z"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip5 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip7a92ee5a-b9ca-4701-8351-616a81f90784">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip6)">
-<g fill-opacity=".24706" fill-rule="evenodd" stroke="none" fill="#a0a0a0">
-  <path d="M 814.56 490.11 L 817.91 261.19 L 937.05 163.92 L 926.77 377.90 z"/>
-<title>Quadrilateral pane_{poly}</title>
-<desc>Quadrilateral pane_{poly}: Polygon pane_A, pane_D, pane_C, pane_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip6 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipff5f6587-1867-49d9-b455-8b7a3cd8d6d4">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip7)">
-<g fill-opacity="1.0000" fill-rule="evenodd" stroke="none" fill="#a0a0a0">
-  <path d="M 468.08 418.48 L 663.82 274.57 L 1057.8 381.86 L 900.67 560.39 z"/>
-<title>Quadrilateral base_{poly}</title>
-<desc>Quadrilateral base_{poly}: Polygon base_D, base_C, base_B, base_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip7 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipc4072261-d2f9-4043-a7f3-497429beeb7d">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip8)">
-<g fill-opacity="1.0000" fill-rule="evenodd" stroke="none" fill="#808080">
-  <path d="M 625.72 357.64 L 630.92 383.82 L 659.36 392.48 L 710.22 382.78 L 703.18 356.64 L 675.30 348.52 z"/>
-<title>Hexagon shad_{poly}</title>
-<desc>Hexagon shad_{poly}: Polygon shad_E, shad_A, shad_D, shad_C, shad_G, shad_F</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip8 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip9d2984cc-bbf9-4e5a-bbe8-7e67be974f27">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip9)">
-<g fill-opacity="1.0000" fill-rule="evenodd" stroke="none" fill="#0099ff">
-  <path d="M 621.36 255.30 L 648.42 219.17 L 700.79 232.72 L 708.41 278.83 L 680.06 313.85 L 627.51 301.56 z"/>
-<title>Hexagon cube_{poly}</title>
-<desc>Hexagon cube_{poly}: Polygon cube_E, cube_H, cube_G, cube_C, cube_B, cube_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip9 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip42763ca2-91e3-476c-b627-811a517467a9">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip10)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 856.67 320.26 L 878.29 278.61"/>
-<title>Segment proj_l</title>
-<desc>Segment proj_l: Segment proj_D, proj_H</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip10 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip16b45ce2-c71e-487f-90fa-d78c7102ec04">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip11)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 878.29 278.61 L 897.70 283.64"/>
-<title>Segment proj_m</title>
-<desc>Segment proj_m: Segment proj_H, proj_G</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip11 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipdaa43ea8-85a5-4484-aef8-ab37dceef829">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip12)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 897.70 283.64 L 876.81 324.34"/>
-<title>Segment proj_n</title>
-<desc>Segment proj_n: Segment proj_G, proj_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip12 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip3ed1406c-2841-4160-961e-7ae7c6abf913">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip13)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 876.81 324.34 L 856.67 320.26"/>
-<title>Segment proj_p</title>
-<desc>Segment proj_p: Segment proj_C, proj_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip13 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip0535f6cd-5981-41bb-943e-2bdcc4ae63da">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip14)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 897.70 283.64 L 896.00 328.22"/>
-<title>Segment proj_q</title>
-<desc>Segment proj_q: Segment proj_G, proj_F</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip14 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip9763f4ae-4b98-48e8-9291-94981f0d56da">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip15)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 896.00 328.22 L 875.37 368.85"/>
-<title>Segment proj_r</title>
-<desc>Segment proj_r: Segment proj_F, proj_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip15 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipfed44a59-50df-4542-923c-75879703bd1e">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip16)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 875.37 368.85 L 876.81 324.34"/>
-<title>Segment proj_s</title>
-<desc>Segment proj_s: Segment proj_B, proj_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip16 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipe5928e25-2d94-4e56-83aa-035c4ca4d90d">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip17)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 875.37 368.85 L 855.47 365.91"/>
-<title>Segment proj_t</title>
-<desc>Segment proj_t: Segment proj_B, proj_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip17 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipe2121bf0-36ed-4e52-9116-c6621fb578f1">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip18)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 855.47 365.91 L 856.67 320.26"/>
-<title>Segment proj_f</title>
-<desc>Segment proj_f: Segment proj_A, proj_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip18 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipf53520b6-952e-43ff-915c-97a3d785c4c8">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip19)">
-<g stroke-linejoin="round" stroke-width="2.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 447.66 125.59 L 1087.7 125.59"/>
-<title>Segment edge_j</title>
-<desc>Segment edge_j: Segment edge_C, Export_2</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip19 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip0eab2e5d-624f-4727-a78d-2bdc92e047c4">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip20)">
-<g stroke-linejoin="round" stroke-width="2.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 1087.7 125.59 L 1087.7 605.59"/>
-<title>Segment edge_k</title>
-<desc>Segment edge_k: Segment Export_2, edge_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip20 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipde26a7e9-3b83-4b6c-8c39-3f4430bee1f1">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip21)">
-<g stroke-linejoin="round" stroke-width="2.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 1087.7 605.59 L 447.66 605.59"/>
-<title>Segment edge_l</title>
-<desc>Segment edge_l: Segment edge_D, Export_1</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip21 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip4776b6c5-af14-4bb4-91a0-2d2d91f5c138">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip22)">
-<g stroke-linejoin="round" stroke-width="2.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 447.66 605.59 L 447.66 125.59"/>
-<title>Segment edge_m</title>
-<desc>Segment edge_m: Segment Export_1, edge_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip22 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip2a13c59b-a5c0-4cf7-aed8-8a71914fe8ac">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip23)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 621.36 255.30 L 648.42 219.17"/>
-<title>Segment cube_n</title>
-<desc>Segment cube_n: Segment cube_E, cube_H</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip23 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip12795918-88cd-4e0f-a3c3-e919bbb9fd20">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip24)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 648.42 219.17 L 700.79 232.72"/>
-<title>Segment cube_o</title>
-<desc>Segment cube_o: Segment cube_H, cube_G</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip24 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip563602d1-5174-4d35-ba5f-330343959bb9">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip25)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 700.79 232.72 L 708.41 278.83"/>
-<title>Segment cube_q</title>
-<desc>Segment cube_q: Segment cube_G, cube_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip25 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipb76d98ec-9e24-4fb4-ba03-321ecf03cc0a">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip26)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 708.41 278.83 L 680.06 313.85"/>
-<title>Segment cube_s</title>
-<desc>Segment cube_s: Segment cube_C, cube_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip26 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip742b9db5-9258-4c79-9012-de7b0ab1014d">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip27)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 680.06 313.85 L 627.51 301.56"/>
-<title>Segment cube_l</title>
-<desc>Segment cube_l: Segment cube_B, cube_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip27 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip77d4e301-760c-4aa9-8d08-21c59493aa01">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip28)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 627.51 301.56 L 621.36 255.30"/>
-<title>Segment cube_m</title>
-<desc>Segment cube_m: Segment cube_A, cube_E</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip28 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipc7788dbf-c2c7-4a8e-ae63-804711959f25">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip29)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 817.91 261.19 L 937.05 163.92"/>
-<title>Segment pane_m</title>
-<desc>Segment pane_m: Segment pane_D, pane_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip29 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipedb4fbb0-5748-46eb-9e38-eaeffe661a77">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip30)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 937.05 163.92 L 926.77 377.90"/>
-<title>Segment pane_n</title>
-<desc>Segment pane_n: Segment pane_C, pane_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip30 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipcd98bb4e-b95a-497f-bff0-584fa2ad3502">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip31)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 926.77 377.90 L 814.56 490.11"/>
-<title>Segment pane_o</title>
-<desc>Segment pane_o: Segment pane_B, pane_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip31 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip4fd3e621-5a8e-4626-ade7-0caf03212f49">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip32)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 814.56 490.11 L 817.91 261.19"/>
-<title>Segment pane_p</title>
-<desc>Segment pane_p: Segment pane_A, pane_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip32 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip37277681-800a-4e9f-985f-065a9f7d850e">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip33)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 625.72 357.64 L 675.30 348.52"/>
-<title>Segment shad_m</title>
-<desc>Segment shad_m: Segment shad_E, shad_F</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip33 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip2fa31931-f551-47bd-b471-0e684945f304">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip34)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 675.30 348.52 L 703.18 356.64"/>
-<title>Segment shad_n</title>
-<desc>Segment shad_n: Segment shad_F, shad_G</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip34 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipd6c71ff5-329e-4e7b-b7c9-508ecfa8d019">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip35)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 703.18 356.64 L 710.22 382.78"/>
-<title>Segment shad_o</title>
-<desc>Segment shad_o: Segment shad_G, shad_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip35 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip1a5597b3-0c2f-4b85-bf39-cf818d500155">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip36)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 710.22 382.78 L 659.36 392.48"/>
-<title>Segment shad_p</title>
-<desc>Segment shad_p: Segment shad_C, shad_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip36 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip0b0ebaa9-cfd5-43a3-acb3-9a86aaed5924">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip37)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 659.36 392.48 L 630.92 383.82"/>
-<title>Segment shad_q</title>
-<desc>Segment shad_q: Segment shad_D, shad_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip37 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip6fc98c7c-2887-4234-8a42-e4bf604bd139">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip38)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 630.92 383.82 L 625.72 357.64"/>
-<title>Segment shad_r</title>
-<desc>Segment shad_r: Segment shad_A, shad_E</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip38 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipe1ff0abc-606d-4cb2-9713-0240dabfcda3">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip39)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 468.08 418.48 L 627.48 301.29"/>
-<title>Segment base_a</title>
-<desc>Segment base_a: Segment base_D, base_E</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip39 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipb51ee0d0-9de6-4ba0-be11-ab87c35df4b7">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip40)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 703.18 285.29 L 1057.8 381.86"/>
-<title>Segment base_b</title>
-<desc>Segment base_b: Segment base_F, base_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip40 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipfc6feb88-d34b-460a-a103-3d96e103f0e0">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip41)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 1057.8 381.86 L 900.67 560.39"/>
-<title>Segment base_c</title>
-<desc>Segment base_c: Segment base_B, base_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip41 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipf8d3b7d2-6bbf-49eb-847b-954aaa6a1170">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip42)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 900.67 560.39 L 468.08 418.48"/>
-<title>Segment base_d</title>
-<desc>Segment base_d: Segment base_A, base_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip42 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipe432f364-27c0-4da2-a740-d953cf80eb53">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip43)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 648.42 219.17 L 655.20 265.74"/>
-<title>Segment cube_r</title>
-<desc>Segment cube_r: Segment cube_H, cube_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip43 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipd97aced3-0e93-4407-8146-4fa27215d055">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip44)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 655.20 265.74 L 627.51 301.56"/>
-<title>Segment cube_t</title>
-<desc>Segment cube_t: Segment cube_D, cube_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip44 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip647ef359-ed63-4f01-a562-00c03f2445fe">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip45)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 655.20 265.74 L 708.41 278.83"/>
-<title>Segment cube_u</title>
-<desc>Segment cube_u: Segment cube_D, cube_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip45 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipfd3d0879-f199-4675-a6b0-2e6e2e7ef8a0">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip46)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 708.20 277.53 L 896.00 328.22"/>
-<title>Segment vect_a</title>
-<desc>Segment vect_a: Segment vect_A, proj_F</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip46 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipbe9ad90a-1f96-4097-839d-38bb78b0e792">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip47)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 708.41 278.83 L 876.81 324.34"/>
-<title>Segment vect_c</title>
-<desc>Segment vect_c: Segment cube_C, proj_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip47 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip053254e4-b399-495d-92b4-79a2c6b6354f">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip48)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 680.06 313.85 L 875.37 368.85"/>
-<title>Segment vect_d</title>
-<desc>Segment vect_d: Segment cube_B, proj_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip48 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip3f9410a5-a3ad-4402-9655-f6f3beaedba6">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip49)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 627.51 301.56 L 855.47 365.91"/>
-<title>Segment vect_e</title>
-<desc>Segment vect_e: Segment cube_A, proj_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip49 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipf8d9bd55-f805-40ec-b9f2-4d3b0f277a8d">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip50)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 648.42 219.17 L 878.29 278.61"/>
-<title>Segment vect_u</title>
-<desc>Segment vect_u: Segment cube_H, proj_H</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip50 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip6dde7d89-f1b1-40b1-969d-284ec35ead48">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip51)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 700.79 232.72 L 897.70 283.64"/>
-<title>Segment vect_v</title>
-<desc>Segment vect_v: Segment cube_G, proj_G</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip51 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip690ae180-1b1c-4bd0-bb65-8303aef3a968">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip52)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 655.20 265.74 L 856.67 320.26"/>
-<title>Segment vect_w</title>
-<desc>Segment vect_w: Segment cube_D, proj_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip52 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip03c8180c-ff05-43e9-90f4-26fcce0cc08b">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip53)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 480.56 174.00 L 482.95 162.55 L 485.31 162.55 L 482.92 174.00 L 480.56 174.00 z M 485.46 170.28 L 487.71 170.17 Q 487.76 171.23 488.07 171.61 Q 488.59 172.22 489.98 172.22 Q 491.13 172.22 491.65 171.80 Q 492.16 171.39 492.16 170.81 Q 492.16 170.30 491.74 169.95 Q 491.45 169.69 490.12 169.11 Q 488.79 168.53 488.17 168.15 Q 487.55 167.77 487.20 167.15 Q 486.85 166.53 486.85 165.70 Q 486.85 164.25 487.90 163.30 Q 488.95 162.34 490.93 162.34 Q 492.95 162.34 494.05 163.29 Q 495.16 164.23 495.27 165.81 L 493.01 165.91 Q 492.93 165.09 492.42 164.66 Q 491.91 164.22 490.91 164.22 Q 489.95 164.22 489.52 164.56 Q 489.10 164.91 489.10 165.42 Q 489.10 165.92 489.49 166.23 Q 489.87 166.56 491.18 167.14 Q 493.16 167.98 493.70 168.52 Q 494.51 169.30 494.51 170.53 Q 494.51 172.05 493.30 173.12 Q 492.10 174.20 489.96 174.20 Q 488.49 174.20 487.41 173.70 Q 486.32 173.20 485.88 172.32 Q 485.43 171.44 485.46 170.28 z M 496.52 169.50 Q 496.52 168.48 496.82 167.36 Q 497.23 165.86 498.04 164.75 Q 498.85 163.64 500.09 162.99 Q 501.34 162.34 502.93 162.34 Q 505.05 162.34 506.36 163.66 Q 507.66 164.98 507.66 167.17 Q 507.66 168.98 506.81 170.68 Q 505.96 172.38 504.50 173.29 Q 503.04 174.20 501.20 174.20 Q 499.60 174.20 498.52 173.48 Q 497.43 172.75 496.98 171.67 Q 496.52 170.59 496.52 169.50 z M 498.85 169.45 Q 498.85 170.64 499.57 171.44 Q 500.29 172.23 501.46 172.23 Q 502.41 172.23 503.29 171.60 Q 504.16 170.97 504.74 169.70 Q 505.32 168.42 505.32 167.20 Q 505.32 165.86 504.59 165.09 Q 503.87 164.31 502.74 164.31 Q 501.01 164.31 499.93 165.92 Q 498.85 167.53 498.85 169.45 z M 514.81 174.00 L 512.58 174.00 L 512.16 164.42 L 510.34 174.00 L 508.22 174.00 L 510.61 162.55 L 513.97 162.55 L 514.31 170.56 L 518.22 162.55 L 521.62 162.55 L 519.22 174.00 L 517.08 174.00 L 519.33 164.50 L 514.81 174.00 z M 521.55 174.00 L 523.94 162.55 L 532.44 162.55 L 532.03 164.45 L 525.91 164.45 L 525.36 167.06 L 531.28 167.06 L 530.89 168.97 L 524.95 168.97 L 524.23 172.08 L 530.91 172.08 L 530.50 174.00 L 521.55 174.00 z M 537.20 174.00 L 534.84 174.00 L 536.84 164.45 L 533.48 164.45 L 533.89 162.55 L 542.91 162.55 L 542.52 164.45 L 539.20 164.45 L 537.20 174.00 z M 544.40 174.00 L 542.04 174.00 L 544.45 162.55 L 549.52 162.55 Q 550.84 162.55 551.57 162.81 Q 552.30 163.08 552.75 163.80 Q 553.20 164.52 553.20 165.55 Q 553.20 167.00 552.32 167.95 Q 551.45 168.91 549.68 169.12 Q 550.13 169.53 550.52 170.20 Q 551.32 171.55 552.29 174.00 L 549.76 174.00 Q 549.45 173.03 548.55 170.97 Q 548.07 169.86 547.52 169.48 Q 547.20 169.25 546.35 169.25 L 545.40 169.25 L 544.40 174.00 z M 545.76 167.53 L 547.01 167.53 Q 548.90 167.53 549.52 167.30 Q 550.15 167.08 550.50 166.59 Q 550.85 166.11 550.85 165.58 Q 550.85 164.95 550.34 164.64 Q 550.02 164.45 548.99 164.45 L 546.40 164.45 L 545.76 167.53 z M 553.45 174.00 L 555.84 162.55 L 558.20 162.55 L 555.81 174.00 L 553.45 174.00 z M 566.29 169.88 L 568.66 170.23 Q 567.98 172.16 566.59 173.18 Q 565.20 174.20 563.32 174.20 Q 561.23 174.20 560.04 172.94 Q 558.85 171.67 558.85 169.27 Q 558.85 167.31 559.65 165.69 Q 560.45 164.06 561.85 163.20 Q 563.26 162.34 564.91 162.34 Q 566.77 162.34 567.92 163.34 Q 569.07 164.34 569.27 166.06 L 567.01 166.28 Q 566.82 165.28 566.29 164.83 Q 565.76 164.38 564.87 164.38 Q 563.88 164.38 563.04 164.97 Q 562.20 165.56 561.69 166.83 Q 561.18 168.09 561.18 169.34 Q 561.18 170.72 561.84 171.47 Q 562.49 172.22 563.48 172.22 Q 564.40 172.22 565.16 171.62 Q 565.91 171.03 566.29 169.88 z"/>
-<title>ISOMETRIC&#xa;(ORTHOGRAPHIC)</title>
-<desc>text1 = “ISOMETRIC&#xa;(ORTHOGRAPHIC)”</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip53 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip1b32284a-0780-4064-87c2-71eef4cf4e5f">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip54)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 483.84 201.38 L 482.31 201.38 Q 481.67 199.88 481.37 198.34 Q 481.06 196.81 481.06 195.55 Q 481.06 193.95 481.57 192.34 Q 482.08 190.73 483.14 189.08 Q 483.80 188.02 485.27 186.34 L 486.97 186.34 Q 485.48 188.09 484.67 189.63 Q 483.86 191.17 483.46 192.98 Q 483.06 194.80 483.06 196.53 Q 483.06 197.70 483.24 198.82 Q 483.42 199.94 483.84 201.38 z M 486.73 193.50 Q 486.73 192.48 487.03 191.36 Q 487.44 189.86 488.25 188.75 Q 489.06 187.64 490.30 186.99 Q 491.55 186.34 493.14 186.34 Q 495.27 186.34 496.57 187.66 Q 497.88 188.98 497.88 191.17 Q 497.88 192.98 497.02 194.68 Q 496.17 196.38 494.71 197.29 Q 493.25 198.20 491.41 198.20 Q 489.81 198.20 488.73 197.48 Q 487.64 196.75 487.19 195.67 Q 486.73 194.59 486.73 193.50 z M 489.06 193.45 Q 489.06 194.64 489.78 195.44 Q 490.50 196.23 491.67 196.23 Q 492.62 196.23 493.50 195.60 Q 494.38 194.97 494.95 193.70 Q 495.53 192.42 495.53 191.20 Q 495.53 189.86 494.80 189.09 Q 494.08 188.31 492.95 188.31 Q 491.22 188.31 490.14 189.92 Q 489.06 191.53 489.06 193.45 z M 500.84 198.00 L 498.48 198.00 L 500.88 186.55 L 505.96 186.55 Q 507.27 186.55 508.01 186.81 Q 508.74 187.08 509.19 187.80 Q 509.63 188.52 509.63 189.55 Q 509.63 191.00 508.76 191.95 Q 507.88 192.91 506.12 193.12 Q 506.57 193.53 506.96 194.20 Q 507.76 195.55 508.73 198.00 L 506.20 198.00 Q 505.88 197.03 504.99 194.97 Q 504.51 193.86 503.96 193.48 Q 503.63 193.25 502.79 193.25 L 501.84 193.25 L 500.84 198.00 z M 502.20 191.53 L 503.45 191.53 Q 505.34 191.53 505.96 191.30 Q 506.59 191.08 506.94 190.59 Q 507.29 190.11 507.29 189.58 Q 507.29 188.95 506.77 188.64 Q 506.46 188.45 505.43 188.45 L 502.84 188.45 L 502.20 191.53 z M 514.97 198.00 L 512.61 198.00 L 514.61 188.45 L 511.25 188.45 L 511.66 186.55 L 520.67 186.55 L 520.28 188.45 L 516.97 188.45 L 514.97 198.00 z M 527.66 192.88 L 523.23 192.88 L 522.16 198.00 L 519.80 198.00 L 522.20 186.55 L 524.55 186.55 L 523.63 190.97 L 528.05 190.97 L 528.99 186.55 L 531.34 186.55 L 528.95 198.00 L 526.59 198.00 L 527.66 192.88 z M 532.06 193.50 Q 532.06 192.48 532.36 191.36 Q 532.77 189.86 533.58 188.75 Q 534.39 187.64 535.63 186.99 Q 536.88 186.34 538.47 186.34 Q 540.59 186.34 541.90 187.66 Q 543.20 188.98 543.20 191.17 Q 543.20 192.98 542.35 194.68 Q 541.50 196.38 540.04 197.29 Q 538.58 198.20 536.73 198.20 Q 535.14 198.20 534.05 197.48 Q 532.97 196.75 532.52 195.67 Q 532.06 194.59 532.06 193.50 z M 534.39 193.45 Q 534.39 194.64 535.11 195.44 Q 535.83 196.23 537.00 196.23 Q 537.95 196.23 538.83 195.60 Q 539.70 194.97 540.28 193.70 Q 540.86 192.42 540.86 191.20 Q 540.86 189.86 540.13 189.09 Q 539.41 188.31 538.28 188.31 Q 536.55 188.31 535.47 189.92 Q 534.39 191.53 534.39 193.45 z M 550.13 191.88 L 555.26 191.88 L 554.23 196.80 Q 553.32 197.38 552.01 197.79 Q 550.70 198.20 549.32 198.20 Q 547.20 198.20 546.07 197.23 Q 544.52 195.92 544.52 193.42 Q 544.52 191.75 545.18 190.22 Q 545.98 188.38 547.45 187.36 Q 548.91 186.34 550.90 186.34 Q 552.88 186.34 554.09 187.27 Q 555.29 188.19 555.68 189.95 L 553.48 190.20 Q 553.20 189.23 552.55 188.74 Q 551.90 188.25 550.93 188.25 Q 549.79 188.25 548.84 188.84 Q 547.88 189.44 547.34 190.68 Q 546.80 191.92 546.80 193.39 Q 546.80 194.84 547.46 195.53 Q 548.12 196.22 549.38 196.22 Q 550.13 196.22 550.93 196.01 Q 551.73 195.80 552.30 195.50 L 552.66 193.80 L 549.74 193.80 L 550.13 191.88 z M 558.61 198.00 L 556.25 198.00 L 558.66 186.55 L 563.73 186.55 Q 565.05 186.55 565.78 186.81 Q 566.52 187.08 566.96 187.80 Q 567.41 188.52 567.41 189.55 Q 567.41 191.00 566.53 191.95 Q 565.66 192.91 563.89 193.12 Q 564.34 193.53 564.73 194.20 Q 565.53 195.55 566.50 198.00 L 563.97 198.00 Q 563.66 197.03 562.77 194.97 Q 562.28 193.86 561.73 193.48 Q 561.41 193.25 560.56 193.25 L 559.61 193.25 L 558.61 198.00 z M 559.97 191.53 L 561.22 191.53 Q 563.11 191.53 563.73 191.30 Q 564.36 191.08 564.71 190.59 Q 565.06 190.11 565.06 189.58 Q 565.06 188.95 564.55 188.64 Q 564.23 188.45 563.20 188.45 L 560.61 188.45 L 559.97 191.53 z M 575.26 195.47 L 570.73 195.47 L 569.35 198.00 L 566.91 198.00 L 573.40 186.55 L 576.02 186.55 L 577.88 198.00 L 575.65 198.00 L 575.26 195.47 z M 574.98 193.56 L 574.30 188.95 L 571.54 193.56 L 574.98 193.56 z M 581.67 198.00 L 579.31 198.00 L 581.70 186.55 L 586.36 186.55 Q 587.61 186.55 588.33 186.84 Q 589.05 187.12 589.47 187.80 Q 589.89 188.48 589.89 189.42 Q 589.89 190.28 589.55 191.10 Q 589.22 191.92 588.73 192.41 Q 588.25 192.91 587.69 193.16 Q 587.12 193.42 586.17 193.55 Q 585.61 193.62 584.09 193.62 L 582.58 193.62 L 581.67 198.00 z M 582.97 191.73 L 583.70 191.73 Q 585.56 191.73 586.19 191.50 Q 586.81 191.27 587.17 190.75 Q 587.53 190.23 587.53 189.61 Q 587.53 189.20 587.35 188.94 Q 587.17 188.67 586.84 188.55 Q 586.50 188.42 585.36 188.42 L 583.67 188.42 L 582.97 191.73 z M 597.89 192.88 L 593.45 192.88 L 592.39 198.00 L 590.03 198.00 L 592.42 186.55 L 594.78 186.55 L 593.86 190.97 L 598.28 190.97 L 599.22 186.55 L 601.56 186.55 L 599.17 198.00 L 596.81 198.00 L 597.89 192.88 z M 601.45 198.00 L 603.84 186.55 L 606.20 186.55 L 603.80 198.00 L 601.45 198.00 z M 614.28 193.88 L 616.66 194.23 Q 615.97 196.16 614.58 197.18 Q 613.19 198.20 611.31 198.20 Q 609.22 198.20 608.03 196.94 Q 606.84 195.67 606.84 193.27 Q 606.84 191.31 607.64 189.69 Q 608.44 188.06 609.84 187.20 Q 611.25 186.34 612.91 186.34 Q 614.77 186.34 615.91 187.34 Q 617.06 188.34 617.27 190.06 L 615.00 190.28 Q 614.81 189.28 614.28 188.83 Q 613.75 188.38 612.86 188.38 Q 611.88 188.38 611.03 188.97 Q 610.19 189.56 609.68 190.83 Q 609.17 192.09 609.17 193.34 Q 609.17 194.72 609.83 195.47 Q 610.48 196.22 611.47 196.22 Q 612.39 196.22 613.15 195.62 Q 613.91 195.03 614.28 193.88 z M 618.77 186.34 L 620.29 186.34 Q 620.93 187.83 621.24 189.36 Q 621.55 190.89 621.55 192.16 Q 621.55 193.75 621.04 195.36 Q 620.52 196.97 619.48 198.64 Q 618.80 199.70 617.34 201.38 L 615.63 201.38 Q 617.12 199.62 617.93 198.09 Q 618.74 196.55 619.14 194.73 Q 619.54 192.92 619.54 191.17 Q 619.54 190.00 619.37 188.89 Q 619.20 187.78 618.77 186.34 z"/>
-<title>ISOMETRIC&#xa;(ORTHOGRAPHIC)</title>
-<desc>text1 = “ISOMETRIC&#xa;(ORTHOGRAPHIC)”</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip54 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipcbe79170-233f-415f-9590-f1ba961320bb">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip55)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#ffffff">
-  <path d="M 41.000 203.00 L 41.000 234.00 C 41.000 236.21 42.791 238.00 45.000 238.00 L 284.00 238.00 C 286.21 238.00 288.00 236.21 288.00 234.00 L 288.00 203.00 C 288.00 200.79 286.21 199.00 284.00 199.00 L 45.000 199.00 C 42.791 199.00 41.000 200.79 41.000 203.00 z"/>
-<title>Button button2</title>
-<desc>button2</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip55 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip4380728e-f5cf-47ac-bf95-2a5aab159c11">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip56)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 41.500 203.50 L 41.500 234.50 C 41.500 236.71 43.291 238.50 45.500 238.50 L 284.50 238.50 C 286.71 238.50 288.50 236.71 288.50 234.50 L 288.50 203.50 C 288.50 201.29 286.71 199.50 284.50 199.50 L 45.500 199.50 C 43.291 199.50 41.500 201.29 41.500 203.50 z"/>
-<title>Button button2</title>
-<desc>button2</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip56 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip9e3f1961-acd3-4964-a981-1f21513479f3">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip57)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 64.109 221.97 L 66.391 222.55 Q 65.672 225.34 63.812 226.82 Q 61.953 228.30 59.266 228.30 Q 56.500 228.30 54.758 227.16 Q 53.016 226.03 52.109 223.88 Q 51.203 221.73 51.203 219.28 Q 51.203 216.59 52.227 214.59 Q 53.250 212.59 55.141 211.56 Q 57.031 210.53 59.312 210.53 Q 61.891 210.53 63.648 211.84 Q 65.406 213.16 66.094 215.53 L 63.859 216.06 Q 63.250 214.19 62.117 213.33 Q 60.984 212.47 59.266 212.47 Q 57.281 212.47 55.953 213.42 Q 54.625 214.38 54.086 215.97 Q 53.547 217.56 53.547 219.27 Q 53.547 221.45 54.180 223.09 Q 54.812 224.73 56.164 225.54 Q 57.516 226.34 59.078 226.34 Q 61.000 226.34 62.320 225.24 Q 63.641 224.14 64.109 221.97 z M 68.863 228.00 L 68.863 210.81 L 70.973 210.81 L 70.973 228.00 L 68.863 228.00 z M 74.258 213.25 L 74.258 210.81 L 76.367 210.81 L 76.367 213.25 L 74.258 213.25 z M 74.258 228.00 L 74.258 215.55 L 76.367 215.55 L 76.367 228.00 L 74.258 228.00 z M 87.699 223.44 L 89.777 223.70 Q 89.434 225.86 88.035 227.07 Q 86.637 228.28 84.590 228.28 Q 82.043 228.28 80.488 226.61 Q 78.934 224.94 78.934 221.83 Q 78.934 219.81 79.605 218.30 Q 80.277 216.78 81.637 216.02 Q 82.996 215.27 84.605 215.27 Q 86.637 215.27 87.926 216.30 Q 89.215 217.33 89.574 219.20 L 87.527 219.53 Q 87.230 218.27 86.488 217.63 Q 85.746 217.00 84.684 217.00 Q 83.090 217.00 82.098 218.15 Q 81.105 219.30 81.105 221.77 Q 81.105 224.27 82.066 225.41 Q 83.027 226.55 84.574 226.55 Q 85.809 226.55 86.645 225.78 Q 87.480 225.02 87.699 223.44 z M 91.590 228.00 L 91.590 210.81 L 93.699 210.81 L 93.699 220.61 L 98.699 215.55 L 101.42 215.55 L 96.668 220.17 L 101.90 228.00 L 99.309 228.00 L 95.184 221.64 L 93.699 223.06 L 93.699 228.00 L 91.590 228.00 z M 114.88 228.00 L 114.88 212.84 L 109.23 212.84 L 109.23 210.81 L 122.85 210.81 L 122.85 212.84 L 117.16 212.84 L 117.16 228.00 L 114.88 228.00 z M 127.20 228.00 L 123.40 215.55 L 125.57 215.55 L 127.56 222.73 L 128.29 225.41 Q 128.34 225.20 128.93 222.84 L 130.92 215.55 L 133.09 215.55 L 134.95 222.77 L 135.57 225.16 L 136.29 222.75 L 138.42 215.55 L 140.46 215.55 L 136.57 228.00 L 134.39 228.00 L 132.40 220.55 L 131.93 218.42 L 129.40 228.00 L 127.20 228.00 z M 142.25 213.25 L 142.25 210.81 L 144.36 210.81 L 144.36 213.25 L 142.25 213.25 z M 142.25 228.00 L 142.25 215.55 L 144.36 215.55 L 144.36 228.00 L 142.25 228.00 z M 155.69 223.44 L 157.77 223.70 Q 157.43 225.86 156.03 227.07 Q 154.63 228.28 152.58 228.28 Q 150.04 228.28 148.48 226.61 Q 146.93 224.94 146.93 221.83 Q 146.93 219.81 147.60 218.30 Q 148.27 216.78 149.63 216.02 Q 150.99 215.27 152.60 215.27 Q 154.63 215.27 155.92 216.30 Q 157.21 217.33 157.57 219.20 L 155.52 219.53 Q 155.22 218.27 154.48 217.63 Q 153.74 217.00 152.68 217.00 Q 151.08 217.00 150.09 218.15 Q 149.10 219.30 149.10 221.77 Q 149.10 224.27 150.06 225.41 Q 151.02 226.55 152.57 226.55 Q 153.80 226.55 154.64 225.78 Q 155.47 225.02 155.69 223.44 z M 168.10 223.98 L 170.27 224.27 Q 169.75 226.17 168.36 227.23 Q 166.97 228.28 164.80 228.28 Q 162.07 228.28 160.46 226.60 Q 158.86 224.92 158.86 221.88 Q 158.86 218.73 160.48 217.00 Q 162.10 215.27 164.68 215.27 Q 167.18 215.27 168.76 216.97 Q 170.35 218.67 170.35 221.75 Q 170.35 221.94 170.33 222.31 L 161.05 222.31 Q 161.16 224.36 162.21 225.45 Q 163.25 226.55 164.82 226.55 Q 165.97 226.55 166.79 225.94 Q 167.61 225.33 168.10 223.98 z M 161.16 220.58 L 168.11 220.58 Q 167.97 219.02 167.32 218.22 Q 166.32 217.00 164.71 217.00 Q 163.25 217.00 162.26 217.98 Q 161.27 218.95 161.16 220.58 z M 184.19 226.11 L 184.50 227.97 Q 183.61 228.17 182.91 228.17 Q 181.75 228.17 181.12 227.80 Q 180.49 227.44 180.23 226.84 Q 179.97 226.25 179.97 224.36 L 179.97 217.19 L 178.43 217.19 L 178.43 215.55 L 179.97 215.55 L 179.97 212.47 L 182.07 211.20 L 182.07 215.55 L 184.19 215.55 L 184.19 217.19 L 182.07 217.19 L 182.07 224.47 Q 182.07 225.38 182.18 225.63 Q 182.30 225.89 182.55 226.04 Q 182.80 226.19 183.27 226.19 Q 183.61 226.19 184.19 226.11 z M 185.47 221.78 Q 185.47 218.31 187.39 216.66 Q 189.00 215.27 191.31 215.27 Q 193.88 215.27 195.50 216.95 Q 197.12 218.64 197.12 221.59 Q 197.12 224.00 196.41 225.38 Q 195.69 226.75 194.31 227.52 Q 192.94 228.28 191.31 228.28 Q 188.69 228.28 187.08 226.60 Q 185.47 224.92 185.47 221.78 z M 187.64 221.78 Q 187.64 224.17 188.68 225.36 Q 189.72 226.55 191.31 226.55 Q 192.88 226.55 193.92 225.35 Q 194.97 224.16 194.97 221.70 Q 194.97 219.39 193.91 218.20 Q 192.86 217.02 191.31 217.02 Q 189.72 217.02 188.68 218.20 Q 187.64 219.39 187.64 221.78 z M 206.58 228.00 L 206.58 210.81 L 214.19 210.81 Q 216.48 210.81 217.68 211.28 Q 218.88 211.75 219.59 212.92 Q 220.31 214.09 220.31 215.50 Q 220.31 217.33 219.12 218.59 Q 217.94 219.84 215.47 220.19 Q 216.38 220.61 216.84 221.03 Q 217.84 221.95 218.73 223.33 L 221.72 228.00 L 218.86 228.00 L 216.58 224.42 Q 215.59 222.88 214.95 222.05 Q 214.30 221.23 213.79 220.91 Q 213.28 220.58 212.75 220.45 Q 212.36 220.38 211.48 220.38 L 208.84 220.38 L 208.84 228.00 L 206.58 228.00 z M 208.84 218.41 L 213.73 218.41 Q 215.30 218.41 216.17 218.08 Q 217.05 217.75 217.51 217.05 Q 217.97 216.34 217.97 215.50 Q 217.97 214.28 217.09 213.50 Q 216.20 212.72 214.28 212.72 L 208.84 212.72 L 208.84 218.41 z M 232.13 223.98 L 234.30 224.27 Q 233.79 226.17 232.39 227.23 Q 231.00 228.28 228.83 228.28 Q 226.10 228.28 224.50 226.60 Q 222.89 224.92 222.89 221.88 Q 222.89 218.73 224.51 217.00 Q 226.13 215.27 228.71 215.27 Q 231.21 215.27 232.79 216.97 Q 234.38 218.67 234.38 221.75 Q 234.38 221.94 234.36 222.31 L 225.08 222.31 Q 225.19 224.36 226.24 225.45 Q 227.29 226.55 228.85 226.55 Q 230.00 226.55 230.82 225.94 Q 231.64 225.33 232.13 223.98 z M 225.19 220.58 L 232.14 220.58 Q 232.00 219.02 231.35 218.22 Q 230.35 217.00 228.74 217.00 Q 227.29 217.00 226.29 217.98 Q 225.30 218.95 225.19 220.58 z M 236.10 224.28 L 238.20 223.95 Q 238.37 225.20 239.17 225.88 Q 239.98 226.55 241.41 226.55 Q 242.87 226.55 243.57 225.95 Q 244.27 225.36 244.27 224.56 Q 244.27 223.84 243.65 223.44 Q 243.23 223.16 241.49 222.72 Q 239.18 222.14 238.28 221.71 Q 237.38 221.28 236.92 220.52 Q 236.46 219.77 236.46 218.86 Q 236.46 218.03 236.84 217.32 Q 237.23 216.61 237.88 216.14 Q 238.37 215.78 239.22 215.52 Q 240.07 215.27 241.04 215.27 Q 242.51 215.27 243.62 215.69 Q 244.73 216.11 245.25 216.84 Q 245.77 217.56 245.98 218.77 L 243.91 219.05 Q 243.77 218.08 243.10 217.54 Q 242.43 217.00 241.20 217.00 Q 239.74 217.00 239.12 217.48 Q 238.49 217.97 238.49 218.61 Q 238.49 219.02 238.76 219.34 Q 239.01 219.69 239.57 219.91 Q 239.88 220.03 241.43 220.45 Q 243.66 221.05 244.55 221.43 Q 245.43 221.81 245.94 222.54 Q 246.45 223.27 246.45 224.34 Q 246.45 225.39 245.83 226.33 Q 245.21 227.27 244.05 227.77 Q 242.90 228.28 241.43 228.28 Q 239.01 228.28 237.73 227.27 Q 236.46 226.27 236.10 224.28 z M 248.96 213.25 L 248.96 210.81 L 251.07 210.81 L 251.07 213.25 L 248.96 213.25 z M 248.96 228.00 L 248.96 215.55 L 251.07 215.55 L 251.07 228.00 L 248.96 228.00 z M 253.17 228.00 L 253.17 226.28 L 261.09 217.19 Q 259.75 217.27 258.71 217.27 L 253.64 217.27 L 253.64 215.55 L 263.81 215.55 L 263.81 216.95 L 257.07 224.84 L 255.78 226.28 Q 257.18 226.19 258.43 226.19 L 264.18 226.19 L 264.18 228.00 L 253.17 228.00 z M 274.81 223.98 L 276.98 224.27 Q 276.46 226.17 275.07 227.23 Q 273.68 228.28 271.51 228.28 Q 268.78 228.28 267.18 226.60 Q 265.57 224.92 265.57 221.88 Q 265.57 218.73 267.19 217.00 Q 268.81 215.27 271.39 215.27 Q 273.89 215.27 275.47 216.97 Q 277.06 218.67 277.06 221.75 Q 277.06 221.94 277.04 222.31 L 267.76 222.31 Q 267.87 224.36 268.92 225.45 Q 269.96 226.55 271.53 226.55 Q 272.68 226.55 273.50 225.94 Q 274.32 225.33 274.81 223.98 z M 267.87 220.58 L 274.82 220.58 Q 274.68 219.02 274.03 218.22 Q 273.03 217.00 271.42 217.00 Q 269.96 217.00 268.97 217.98 Q 267.98 218.95 267.87 220.58 z"/>
-<title>Button button2</title>
-<desc>button2</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip57 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clipb7efa8e1-441c-4ff6-a46f-e92ff3eba5ab">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip58)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#ffffff">
-  <path d="M 46.000 144.00 L 46.000 175.00 C 46.000 177.21 47.791 179.00 50.000 179.00 L 261.00 179.00 C 263.21 179.00 265.00 177.21 265.00 175.00 L 265.00 144.00 C 265.00 141.79 263.21 140.00 261.00 140.00 L 50.000 140.00 C 47.791 140.00 46.000 141.79 46.000 144.00 z"/>
-<title>Button button1</title>
-<desc>button1</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip58 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip5c2404b2-5457-4abd-a4a0-1fb48ed7dbce">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip59)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 46.500 144.50 L 46.500 175.50 C 46.500 177.71 48.291 179.50 50.500 179.50 L 261.50 179.50 C 263.71 179.50 265.50 177.71 265.50 175.50 L 265.50 144.50 C 265.50 142.29 263.71 140.50 261.50 140.50 L 50.500 140.50 C 48.291 140.50 46.500 142.29 46.500 144.50 z"/>
-<title>Button button1</title>
-<desc>button1</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip59 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -447.66, -125.59)">
-<clipPath id="clip91211c0f-0ab6-44a8-b328-7b4621436edc">
-  <path d="M 447.66 125.59 L 447.66 607.59 L 1089.7 607.59 L 1089.7 125.59 z"/>
-</clipPath>
-<g clip-path="url(#clip60)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 69.109 162.97 L 71.391 163.55 Q 70.672 166.34 68.812 167.82 Q 66.953 169.30 64.266 169.30 Q 61.500 169.30 59.758 168.16 Q 58.016 167.03 57.109 164.88 Q 56.203 162.73 56.203 160.28 Q 56.203 157.59 57.227 155.59 Q 58.250 153.59 60.141 152.56 Q 62.031 151.53 64.312 151.53 Q 66.891 151.53 68.648 152.84 Q 70.406 154.16 71.094 156.53 L 68.859 157.06 Q 68.250 155.19 67.117 154.33 Q 65.984 153.47 64.266 153.47 Q 62.281 153.47 60.953 154.42 Q 59.625 155.38 59.086 156.97 Q 58.547 158.56 58.547 160.27 Q 58.547 162.45 59.180 164.09 Q 59.812 165.73 61.164 166.54 Q 62.516 167.34 64.078 167.34 Q 66.000 167.34 67.320 166.24 Q 68.641 165.14 69.109 162.97 z M 73.863 169.00 L 73.863 151.81 L 75.973 151.81 L 75.973 169.00 L 73.863 169.00 z M 79.258 154.25 L 79.258 151.81 L 81.367 151.81 L 81.367 154.25 L 79.258 154.25 z M 79.258 169.00 L 79.258 156.55 L 81.367 156.55 L 81.367 169.00 L 79.258 169.00 z M 92.699 164.44 L 94.777 164.70 Q 94.434 166.86 93.035 168.07 Q 91.637 169.28 89.590 169.28 Q 87.043 169.28 85.488 167.61 Q 83.934 165.94 83.934 162.83 Q 83.934 160.81 84.605 159.30 Q 85.277 157.78 86.637 157.02 Q 87.996 156.27 89.605 156.27 Q 91.637 156.27 92.926 157.30 Q 94.215 158.33 94.574 160.20 L 92.527 160.53 Q 92.230 159.27 91.488 158.63 Q 90.746 158.00 89.684 158.00 Q 88.090 158.00 87.098 159.15 Q 86.105 160.30 86.105 162.77 Q 86.105 165.27 87.066 166.41 Q 88.027 167.55 89.574 167.55 Q 90.809 167.55 91.645 166.78 Q 92.480 166.02 92.699 164.44 z M 96.590 169.00 L 96.590 151.81 L 98.699 151.81 L 98.699 161.61 L 103.70 156.55 L 106.42 156.55 L 101.67 161.17 L 106.90 169.00 L 104.31 169.00 L 100.18 162.64 L 98.699 164.06 L 98.699 169.00 L 96.590 169.00 z M 119.85 167.11 L 120.16 168.97 Q 119.27 169.17 118.57 169.17 Q 117.41 169.17 116.78 168.80 Q 116.15 168.44 115.89 167.84 Q 115.63 167.25 115.63 165.36 L 115.63 158.19 L 114.09 158.19 L 114.09 156.55 L 115.63 156.55 L 115.63 153.47 L 117.73 152.20 L 117.73 156.55 L 119.85 156.55 L 119.85 158.19 L 117.73 158.19 L 117.73 165.47 Q 117.73 166.38 117.84 166.63 Q 117.96 166.89 118.21 167.04 Q 118.46 167.19 118.93 167.19 Q 119.27 167.19 119.85 167.11 z M 121.13 162.78 Q 121.13 159.31 123.05 157.66 Q 124.66 156.27 126.97 156.27 Q 129.54 156.27 131.16 157.95 Q 132.79 159.64 132.79 162.59 Q 132.79 165.00 132.07 166.38 Q 131.35 167.75 129.97 168.52 Q 128.60 169.28 126.97 169.28 Q 124.35 169.28 122.74 167.60 Q 121.13 165.92 121.13 162.78 z M 123.30 162.78 Q 123.30 165.17 124.34 166.36 Q 125.38 167.55 126.97 167.55 Q 128.54 167.55 129.58 166.35 Q 130.63 165.16 130.63 162.70 Q 130.63 160.39 129.57 159.20 Q 128.52 158.02 126.97 158.02 Q 125.38 158.02 124.34 159.20 Q 123.30 160.39 123.30 162.78 z M 142.21 169.00 L 142.21 151.81 L 148.68 151.81 Q 150.39 151.81 151.30 151.98 Q 152.57 152.19 153.42 152.78 Q 154.27 153.38 154.79 154.45 Q 155.32 155.52 155.32 156.78 Q 155.32 158.98 153.92 160.50 Q 152.52 162.02 148.88 162.02 L 144.47 162.02 L 144.47 169.00 L 142.21 169.00 z M 144.47 159.98 L 148.91 159.98 Q 151.11 159.98 152.04 159.16 Q 152.97 158.34 152.97 156.86 Q 152.97 155.78 152.43 155.02 Q 151.88 154.25 150.99 154.00 Q 150.41 153.84 148.86 153.84 L 144.47 153.84 L 144.47 159.98 z M 157.89 169.00 L 157.89 151.81 L 160.00 151.81 L 160.00 169.00 L 157.89 169.00 z M 162.48 162.78 Q 162.48 159.31 164.41 157.66 Q 166.02 156.27 168.33 156.27 Q 170.89 156.27 172.52 157.95 Q 174.14 159.64 174.14 162.59 Q 174.14 165.00 173.42 166.38 Q 172.70 167.75 171.33 168.52 Q 169.95 169.28 168.33 169.28 Q 165.70 169.28 164.09 167.60 Q 162.48 165.92 162.48 162.78 z M 164.66 162.78 Q 164.66 165.17 165.70 166.36 Q 166.73 167.55 168.33 167.55 Q 169.89 167.55 170.94 166.35 Q 171.98 165.16 171.98 162.70 Q 171.98 160.39 170.93 159.20 Q 169.88 158.02 168.33 158.02 Q 166.73 158.02 165.70 159.20 Q 164.66 160.39 164.66 162.78 z M 181.22 167.11 L 181.54 168.97 Q 180.64 169.17 179.94 169.17 Q 178.79 169.17 178.15 168.80 Q 177.52 168.44 177.26 167.84 Q 177.00 167.25 177.00 165.36 L 177.00 158.19 L 175.46 158.19 L 175.46 156.55 L 177.00 156.55 L 177.00 153.47 L 179.10 152.20 L 179.10 156.55 L 181.22 156.55 L 181.22 158.19 L 179.10 158.19 L 179.10 165.47 Q 179.10 166.38 179.21 166.63 Q 179.33 166.89 179.58 167.04 Q 179.83 167.19 180.30 167.19 Q 180.64 167.19 181.22 167.11 z M 190.23 169.00 L 190.23 151.81 L 196.70 151.81 Q 198.42 151.81 199.32 151.98 Q 200.59 152.19 201.44 152.78 Q 202.29 153.38 202.82 154.45 Q 203.34 155.52 203.34 156.78 Q 203.34 158.98 201.94 160.50 Q 200.54 162.02 196.90 162.02 L 192.50 162.02 L 192.50 169.00 L 190.23 169.00 z M 192.50 159.98 L 196.93 159.98 Q 199.14 159.98 200.07 159.16 Q 201.00 158.34 201.00 156.86 Q 201.00 155.78 200.45 155.02 Q 199.90 154.25 199.01 154.00 Q 198.43 153.84 196.89 153.84 L 192.50 153.84 L 192.50 159.98 z M 205.18 162.78 Q 205.18 159.31 207.10 157.66 Q 208.71 156.27 211.02 156.27 Q 213.58 156.27 215.21 157.95 Q 216.83 159.64 216.83 162.59 Q 216.83 165.00 216.11 166.38 Q 215.39 167.75 214.02 168.52 Q 212.64 169.28 211.02 169.28 Q 208.39 169.28 206.79 167.60 Q 205.18 165.92 205.18 162.78 z M 207.35 162.78 Q 207.35 165.17 208.39 166.36 Q 209.43 167.55 211.02 167.55 Q 212.58 167.55 213.63 166.35 Q 214.68 165.16 214.68 162.70 Q 214.68 160.39 213.62 159.20 Q 212.57 158.02 211.02 158.02 Q 209.43 158.02 208.39 159.20 Q 207.35 160.39 207.35 162.78 z M 219.32 154.25 L 219.32 151.81 L 221.43 151.81 L 221.43 154.25 L 219.32 154.25 z M 219.32 169.00 L 219.32 156.55 L 221.43 156.55 L 221.43 169.00 L 219.32 169.00 z M 224.64 169.00 L 224.64 156.55 L 226.54 156.55 L 226.54 158.33 Q 227.92 156.27 230.50 156.27 Q 231.62 156.27 232.57 156.67 Q 233.51 157.08 233.98 157.73 Q 234.45 158.39 234.64 159.30 Q 234.76 159.88 234.76 161.34 L 234.76 169.00 L 232.65 169.00 L 232.65 161.42 Q 232.65 160.14 232.40 159.50 Q 232.15 158.86 231.53 158.48 Q 230.90 158.09 230.06 158.09 Q 228.71 158.09 227.73 158.95 Q 226.75 159.81 226.75 162.20 L 226.75 169.00 L 224.64 169.00 z M 242.59 167.11 L 242.91 168.97 Q 242.02 169.17 241.31 169.17 Q 240.16 169.17 239.52 168.80 Q 238.89 168.44 238.63 167.84 Q 238.38 167.25 238.38 165.36 L 238.38 158.19 L 236.83 158.19 L 236.83 156.55 L 238.38 156.55 L 238.38 153.47 L 240.47 152.20 L 240.47 156.55 L 242.59 156.55 L 242.59 158.19 L 240.47 158.19 L 240.47 165.47 Q 240.47 166.38 240.59 166.63 Q 240.70 166.89 240.95 167.04 Q 241.20 167.19 241.67 167.19 Q 242.02 167.19 242.59 167.11 z M 243.81 165.28 L 245.90 164.95 Q 246.07 166.20 246.88 166.88 Q 247.68 167.55 249.12 167.55 Q 250.57 167.55 251.28 166.95 Q 251.98 166.36 251.98 165.56 Q 251.98 164.84 251.36 164.44 Q 250.93 164.16 249.20 163.72 Q 246.89 163.14 245.99 162.71 Q 245.09 162.28 244.63 161.52 Q 244.17 160.77 244.17 159.86 Q 244.17 159.03 244.55 158.32 Q 244.93 157.61 245.59 157.14 Q 246.07 156.78 246.93 156.52 Q 247.78 156.27 248.75 156.27 Q 250.21 156.27 251.32 156.69 Q 252.43 157.11 252.96 157.84 Q 253.48 158.56 253.68 159.77 L 251.62 160.05 Q 251.48 159.08 250.81 158.54 Q 250.14 158.00 248.90 158.00 Q 247.45 158.00 246.82 158.48 Q 246.20 158.97 246.20 159.61 Q 246.20 160.02 246.46 160.34 Q 246.71 160.69 247.28 160.91 Q 247.59 161.03 249.14 161.45 Q 251.37 162.05 252.25 162.43 Q 253.14 162.81 253.64 163.54 Q 254.15 164.27 254.15 165.34 Q 254.15 166.39 253.54 167.33 Q 252.92 168.27 251.76 168.77 Q 250.61 169.28 249.14 169.28 Q 246.71 169.28 245.44 168.27 Q 244.17 167.27 243.81 165.28 z"/>
-<title>Button button1</title>
-<desc>button1</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip60 -->
-</g> <!-- transform -->
-</g><!-- layer0 -->
-</g> <!-- default stroke -->
-
-
-
-<!-- IMAGE4 CABINET ******************************************************** -->
-<g stroke-linejoin="miter" stroke-dashoffset="0.0000" stroke-dasharray="none" stroke-width="1.0000" stroke-miterlimit="10.000" stroke-linecap="square" transform="translate(0,0)">
-<g id="misc">
-</g><!-- misc -->
-<g id="layer0">
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip424d5dac-5350-44da-8045-3c665a946780">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip1)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 1238.5 360.00 L 1238.5 381.00 C 1238.5 382.38 1239.6 383.50 1241.0 383.50 L 1262.0 383.50 C 1263.4 383.50 1264.5 382.38 1264.5 381.00 L 1264.5 360.00 C 1264.5 358.62 1263.4 357.50 1262.0 357.50 L 1241.0 357.50 C 1239.6 357.50 1238.5 358.62 1238.5 360.00 z"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip1 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clipaf258db5-6ddf-4022-8de7-bda2496afdee">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip2)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#ffffff">
-  <path d="M 1239.0 360.50 L 1239.0 379.50 C 1239.0 380.88 1240.1 382.00 1241.5 382.00 L 1260.5 382.00 C 1261.9 382.00 1263.0 380.88 1263.0 379.50 L 1263.0 360.50 C 1263.0 359.12 1261.9 358.00 1260.5 358.00 L 1241.5 358.00 C 1240.1 358.00 1239.0 359.12 1239.0 360.50 z"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip2 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip447b4ba6-6ce9-454a-8897-0facf861956e">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip3)">
-<g stroke-linejoin="round" stroke-width="4.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#444444">
-  <path d="M 1243.5 372.50 L 1248.5 377.50"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip3 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip860dc49e-f584-4da3-862f-6af3e62e07de">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip4)">
-<g stroke-linejoin="round" stroke-width="4.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#444444">
-  <path d="M 1248.5 377.50 L 1258.5 363.50"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip4 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip2fac3668-5d49-4b8a-8961-80dc130da869">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip5)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 1277.2 377.00 L 1277.2 366.89 L 1273.4 366.89 L 1273.4 365.55 L 1282.5 365.55 L 1282.5 366.89 L 1278.7 366.89 L 1278.7 377.00 L 1277.2 377.00 z M 1283.3 372.84 Q 1283.3 370.55 1284.6 369.44 Q 1285.7 368.52 1287.2 368.52 Q 1288.9 368.52 1290.0 369.63 Q 1291.1 370.75 1291.1 372.73 Q 1291.1 374.33 1290.6 375.25 Q 1290.1 376.17 1289.2 376.68 Q 1288.3 377.19 1287.2 377.19 Q 1285.5 377.19 1284.4 376.07 Q 1283.3 374.95 1283.3 372.84 z M 1284.8 372.84 Q 1284.8 374.44 1285.5 375.23 Q 1286.1 376.03 1287.2 376.03 Q 1288.2 376.03 1288.9 375.23 Q 1289.6 374.44 1289.6 372.80 Q 1289.6 371.27 1288.9 370.47 Q 1288.2 369.67 1287.2 369.67 Q 1286.1 369.67 1285.5 370.46 Q 1284.8 371.25 1284.8 372.84 z M 1292.5 377.69 L 1293.8 377.89 Q 1293.9 378.53 1294.3 378.81 Q 1294.8 379.20 1295.8 379.20 Q 1296.7 379.20 1297.2 378.81 Q 1297.8 378.42 1298.0 377.72 Q 1298.1 377.30 1298.1 375.91 Q 1297.2 377.00 1295.8 377.00 Q 1294.1 377.00 1293.1 375.77 Q 1292.2 374.53 1292.2 372.80 Q 1292.2 371.61 1292.6 370.61 Q 1293.0 369.61 1293.9 369.06 Q 1294.7 368.52 1295.8 368.52 Q 1297.2 368.52 1298.2 369.70 L 1298.2 368.70 L 1299.5 368.70 L 1299.5 375.88 Q 1299.5 377.81 1299.1 378.62 Q 1298.7 379.44 1297.9 379.91 Q 1297.0 380.38 1295.8 380.38 Q 1294.3 380.38 1293.4 379.70 Q 1292.4 379.03 1292.5 377.69 z M 1293.6 372.70 Q 1293.6 374.33 1294.3 375.08 Q 1294.9 375.83 1295.9 375.83 Q 1296.9 375.83 1297.5 375.09 Q 1298.2 374.34 1298.2 372.75 Q 1298.2 371.22 1297.5 370.45 Q 1296.8 369.67 1295.9 369.67 Q 1295.0 369.67 1294.3 370.44 Q 1293.6 371.20 1293.6 372.70 z M 1301.4 377.69 L 1302.7 377.89 Q 1302.8 378.53 1303.2 378.81 Q 1303.7 379.20 1304.6 379.20 Q 1305.6 379.20 1306.1 378.81 Q 1306.7 378.42 1306.9 377.72 Q 1307.0 377.30 1307.0 375.91 Q 1306.1 377.00 1304.7 377.00 Q 1303.0 377.00 1302.0 375.77 Q 1301.1 374.53 1301.1 372.80 Q 1301.1 371.61 1301.5 370.61 Q 1301.9 369.61 1302.8 369.06 Q 1303.6 368.52 1304.7 368.52 Q 1306.1 368.52 1307.1 369.70 L 1307.1 368.70 L 1308.4 368.70 L 1308.4 375.88 Q 1308.4 377.81 1308.0 378.62 Q 1307.6 379.44 1306.8 379.91 Q 1305.9 380.38 1304.6 380.38 Q 1303.2 380.38 1302.2 379.70 Q 1301.3 379.03 1301.4 377.69 z M 1302.5 372.70 Q 1302.5 374.33 1303.2 375.08 Q 1303.8 375.83 1304.8 375.83 Q 1305.8 375.83 1306.4 375.09 Q 1307.1 374.34 1307.1 372.75 Q 1307.1 371.22 1306.4 370.45 Q 1305.7 369.67 1304.8 369.67 Q 1303.9 369.67 1303.2 370.44 Q 1302.5 371.20 1302.5 372.70 z M 1310.5 377.00 L 1310.5 365.55 L 1311.9 365.55 L 1311.9 377.00 L 1310.5 377.00 z M 1319.8 374.33 L 1321.2 374.50 Q 1320.9 375.78 1319.9 376.48 Q 1319.0 377.19 1317.6 377.19 Q 1315.7 377.19 1314.7 376.06 Q 1313.6 374.94 1313.6 372.92 Q 1313.6 370.83 1314.7 369.67 Q 1315.8 368.52 1317.5 368.52 Q 1319.1 368.52 1320.2 369.65 Q 1321.3 370.78 1321.3 372.83 Q 1321.3 372.95 1321.3 373.20 L 1315.1 373.20 Q 1315.1 374.58 1315.8 375.30 Q 1316.5 376.03 1317.6 376.03 Q 1318.4 376.03 1318.9 375.62 Q 1319.4 375.22 1319.8 374.33 z M 1315.1 372.05 L 1319.8 372.05 Q 1319.7 371.00 1319.2 370.48 Q 1318.6 369.67 1317.5 369.67 Q 1316.5 369.67 1315.9 370.32 Q 1315.2 370.97 1315.1 372.05 z M 1333.1 374.33 L 1334.6 374.50 Q 1334.2 375.78 1333.3 376.48 Q 1332.4 377.19 1330.9 377.19 Q 1329.1 377.19 1328.0 376.06 Q 1327.0 374.94 1327.0 372.92 Q 1327.0 370.83 1328.0 369.67 Q 1329.1 368.52 1330.8 368.52 Q 1332.5 368.52 1333.5 369.65 Q 1334.6 370.78 1334.6 372.83 Q 1334.6 372.95 1334.6 373.20 L 1328.4 373.20 Q 1328.5 374.58 1329.2 375.30 Q 1329.9 376.03 1330.9 376.03 Q 1331.7 376.03 1332.2 375.62 Q 1332.8 375.22 1333.1 374.33 z M 1328.5 372.05 L 1333.1 372.05 Q 1333.0 371.00 1332.6 370.48 Q 1331.9 369.67 1330.9 369.67 Q 1329.9 369.67 1329.2 370.32 Q 1328.6 370.97 1328.5 372.05 z M 1335.4 377.00 L 1338.4 372.69 L 1335.6 368.70 L 1337.4 368.70 L 1338.6 370.64 Q 1339.0 371.20 1339.2 371.58 Q 1339.6 371.06 1339.9 370.66 L 1341.2 368.70 L 1342.9 368.70 L 1340.1 372.61 L 1343.2 377.00 L 1341.4 377.00 L 1339.7 374.42 L 1339.3 373.72 L 1337.1 377.00 L 1335.4 377.00 z M 1344.3 380.19 L 1344.3 368.70 L 1345.6 368.70 L 1345.6 369.78 Q 1346.1 369.14 1346.6 368.83 Q 1347.2 368.52 1348.0 368.52 Q 1349.1 368.52 1349.9 369.06 Q 1350.7 369.61 1351.1 370.60 Q 1351.5 371.59 1351.5 372.78 Q 1351.5 374.06 1351.1 375.08 Q 1350.6 376.09 1349.7 376.64 Q 1348.9 377.19 1347.9 377.19 Q 1347.2 377.19 1346.6 376.89 Q 1346.1 376.59 1345.7 376.14 L 1345.7 380.19 L 1344.3 380.19 z M 1345.6 372.89 Q 1345.6 374.50 1346.2 375.27 Q 1346.9 376.03 1347.8 376.03 Q 1348.8 376.03 1349.4 375.23 Q 1350.1 374.44 1350.1 372.78 Q 1350.1 371.19 1349.4 370.40 Q 1348.8 369.61 1347.9 369.61 Q 1347.0 369.61 1346.3 370.45 Q 1345.6 371.30 1345.6 372.89 z M 1352.7 372.84 Q 1352.7 370.55 1354.0 369.44 Q 1355.1 368.52 1356.6 368.52 Q 1358.3 368.52 1359.4 369.63 Q 1360.5 370.75 1360.5 372.73 Q 1360.5 374.33 1360.0 375.25 Q 1359.5 376.17 1358.6 376.68 Q 1357.7 377.19 1356.6 377.19 Q 1354.9 377.19 1353.8 376.07 Q 1352.7 374.95 1352.7 372.84 z M 1354.1 372.84 Q 1354.1 374.44 1354.8 375.23 Q 1355.5 376.03 1356.6 376.03 Q 1357.6 376.03 1358.3 375.23 Q 1359.0 374.44 1359.0 372.80 Q 1359.0 371.27 1358.3 370.47 Q 1357.6 369.67 1356.6 369.67 Q 1355.5 369.67 1354.8 370.46 Q 1354.1 371.25 1354.1 372.84 z M 1362.1 377.00 L 1362.1 368.70 L 1363.4 368.70 L 1363.4 369.95 Q 1363.9 369.08 1364.3 368.80 Q 1364.7 368.52 1365.2 368.52 Q 1365.9 368.52 1366.6 368.97 L 1366.1 370.27 Q 1365.6 369.97 1365.1 369.97 Q 1364.6 369.97 1364.3 370.24 Q 1363.9 370.52 1363.8 371.02 Q 1363.5 371.77 1363.5 372.66 L 1363.5 377.00 L 1362.1 377.00 z M 1370.5 375.73 L 1370.7 376.98 Q 1370.1 377.11 1369.7 377.11 Q 1368.9 377.11 1368.5 376.87 Q 1368.0 376.62 1367.9 376.23 Q 1367.7 375.83 1367.7 374.56 L 1367.7 369.80 L 1366.7 369.80 L 1366.7 368.70 L 1367.7 368.70 L 1367.7 366.64 L 1369.1 365.80 L 1369.1 368.70 L 1370.5 368.70 L 1370.5 369.80 L 1369.1 369.80 L 1369.1 374.64 Q 1369.1 375.25 1369.2 375.42 Q 1369.2 375.59 1369.4 375.70 Q 1369.6 375.80 1369.9 375.80 Q 1370.1 375.80 1370.5 375.73 z M 1382.0 374.33 L 1383.5 374.50 Q 1383.1 375.78 1382.2 376.48 Q 1381.3 377.19 1379.8 377.19 Q 1378.0 377.19 1376.9 376.06 Q 1375.9 374.94 1375.9 372.92 Q 1375.9 370.83 1377.0 369.67 Q 1378.0 368.52 1379.8 368.52 Q 1381.4 368.52 1382.5 369.65 Q 1383.5 370.78 1383.5 372.83 Q 1383.5 372.95 1383.5 373.20 L 1377.3 373.20 Q 1377.4 374.58 1378.1 375.30 Q 1378.8 376.03 1379.8 376.03 Q 1380.6 376.03 1381.2 375.62 Q 1381.7 375.22 1382.0 374.33 z M 1377.4 372.05 L 1382.0 372.05 Q 1381.9 371.00 1381.5 370.48 Q 1380.8 369.67 1379.8 369.67 Q 1378.8 369.67 1378.1 370.32 Q 1377.5 370.97 1377.4 372.05 z M 1390.6 377.00 L 1390.6 375.95 Q 1389.8 377.19 1388.3 377.19 Q 1387.3 377.19 1386.5 376.64 Q 1385.6 376.09 1385.2 375.11 Q 1384.7 374.12 1384.7 372.86 Q 1384.7 371.61 1385.1 370.60 Q 1385.6 369.59 1386.4 369.05 Q 1387.2 368.52 1388.2 368.52 Q 1389.0 368.52 1389.6 368.83 Q 1390.2 369.14 1390.5 369.66 L 1390.5 365.55 L 1391.9 365.55 L 1391.9 377.00 L 1390.6 377.00 z M 1386.2 372.86 Q 1386.2 374.45 1386.9 375.24 Q 1387.5 376.03 1388.4 376.03 Q 1389.4 376.03 1390.0 375.27 Q 1390.6 374.52 1390.6 372.97 Q 1390.6 371.27 1390.0 370.47 Q 1389.3 369.67 1388.4 369.67 Q 1387.4 369.67 1386.8 370.44 Q 1386.2 371.20 1386.2 372.86 z M 1393.9 377.69 L 1395.2 377.89 Q 1395.3 378.53 1395.7 378.81 Q 1396.2 379.20 1397.2 379.20 Q 1398.1 379.20 1398.7 378.81 Q 1399.2 378.42 1399.4 377.72 Q 1399.5 377.30 1399.5 375.91 Q 1398.6 377.00 1397.2 377.00 Q 1395.5 377.00 1394.5 375.77 Q 1393.6 374.53 1393.6 372.80 Q 1393.6 371.61 1394.0 370.61 Q 1394.5 369.61 1395.3 369.06 Q 1396.1 368.52 1397.2 368.52 Q 1398.7 368.52 1399.6 369.70 L 1399.6 368.70 L 1400.9 368.70 L 1400.9 375.88 Q 1400.9 377.81 1400.5 378.62 Q 1400.1 379.44 1399.3 379.91 Q 1398.4 380.38 1397.2 380.38 Q 1395.7 380.38 1394.8 379.70 Q 1393.8 379.03 1393.9 377.69 z M 1395.0 372.70 Q 1395.0 374.33 1395.7 375.08 Q 1396.3 375.83 1397.3 375.83 Q 1398.3 375.83 1398.9 375.09 Q 1399.6 374.34 1399.6 372.75 Q 1399.6 371.22 1398.9 370.45 Q 1398.2 369.67 1397.3 369.67 Q 1396.4 369.67 1395.7 370.44 Q 1395.0 371.20 1395.0 372.70 z M 1408.7 374.33 L 1410.2 374.50 Q 1409.8 375.78 1408.9 376.48 Q 1408.0 377.19 1406.5 377.19 Q 1404.7 377.19 1403.6 376.06 Q 1402.6 374.94 1402.6 372.92 Q 1402.6 370.83 1403.6 369.67 Q 1404.7 368.52 1406.4 368.52 Q 1408.1 368.52 1409.2 369.65 Q 1410.2 370.78 1410.2 372.83 Q 1410.2 372.95 1410.2 373.20 L 1404.0 373.20 Q 1404.1 374.58 1404.8 375.30 Q 1405.5 376.03 1406.5 376.03 Q 1407.3 376.03 1407.9 375.62 Q 1408.4 375.22 1408.7 374.33 z M 1404.1 372.05 L 1408.7 372.05 Q 1408.6 371.00 1408.2 370.48 Q 1407.5 369.67 1406.5 369.67 Q 1405.5 369.67 1404.8 370.32 Q 1404.2 370.97 1404.1 372.05 z M 1411.4 374.52 L 1412.8 374.30 Q 1412.9 375.14 1413.4 375.59 Q 1414.0 376.03 1414.9 376.03 Q 1415.9 376.03 1416.3 375.63 Q 1416.8 375.23 1416.8 374.70 Q 1416.8 374.23 1416.4 373.95 Q 1416.1 373.77 1415.0 373.48 Q 1413.4 373.09 1412.8 372.80 Q 1412.2 372.52 1411.9 372.02 Q 1411.6 371.52 1411.6 370.91 Q 1411.6 370.34 1411.9 369.88 Q 1412.1 369.41 1412.5 369.09 Q 1412.9 368.84 1413.4 368.68 Q 1414.0 368.52 1414.7 368.52 Q 1415.6 368.52 1416.4 368.80 Q 1417.1 369.08 1417.5 369.55 Q 1417.8 370.03 1418.0 370.84 L 1416.6 371.03 Q 1416.5 370.39 1416.0 370.03 Q 1415.6 369.67 1414.8 369.67 Q 1413.8 369.67 1413.4 369.99 Q 1413.0 370.31 1413.0 370.73 Q 1413.0 371.02 1413.1 371.23 Q 1413.3 371.45 1413.7 371.61 Q 1413.9 371.69 1414.9 371.97 Q 1416.4 372.36 1417.0 372.62 Q 1417.6 372.88 1417.9 373.36 Q 1418.3 373.84 1418.3 374.56 Q 1418.3 375.27 1417.9 375.88 Q 1417.4 376.50 1416.7 376.84 Q 1415.9 377.19 1414.9 377.19 Q 1413.3 377.19 1412.5 376.52 Q 1411.6 375.84 1411.4 374.52 z"/>
-<title>Boolean Value bool_o</title>
-<desc>bool_o = true</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip5 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip3b8c7c06-b57d-4717-ba82-7a9138b8dd26">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip6)">
-<g fill-opacity=".24706" fill-rule="evenodd" stroke="none" fill="#a0a0a0">
-  <path d="M 796.21 534.21 L 799.56 305.29 L 918.69 208.02 L 908.42 422.00 z"/>
-<title>Quadrilateral pane_{poly}</title>
-<desc>Quadrilateral pane_{poly}: Polygon pane_A, pane_D, pane_C, pane_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip6 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clipff5b870a-efaf-4801-a72a-49ab2f44e079">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip7)">
-<g fill-opacity="1.0000" fill-rule="evenodd" stroke="none" fill="#a0a0a0">
-  <path d="M 449.73 462.58 L 645.46 318.67 L 1039.4 425.96 L 882.32 604.49 z"/>
-<title>Quadrilateral base_{poly}</title>
-<desc>Quadrilateral base_{poly}: Polygon base_D, base_C, base_B, base_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip7 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip2ce1e8ca-84f1-4b43-b66b-00ea17c10b66">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip8)">
-<g fill-opacity="1.0000" fill-rule="evenodd" stroke="none" fill="#808080">
-  <path d="M 561.86 456.60 L 595.48 430.12 L 644.91 445.26 L 611.99 472.46 z"/>
-<title>Quadrilateral shad_{poly}</title>
-<desc>Quadrilateral shad_{poly}: Polygon shad_H, shad_G, shad_C, shad_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip8 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip54a11760-83ca-43a0-acc0-ddadb2526cb5">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip9)">
-<g fill-opacity="1.0000" fill-rule="evenodd" stroke="none" fill="#0099ff">
-  <path d="M 558.62 399.98 L 592.89 374.38 L 643.12 389.01 L 644.77 440.88 L 611.81 468.01 L 561.61 452.19 z"/>
-<title>Hexagon cube_{poly}</title>
-<desc>Hexagon cube_{poly}: Polygon cube_H, cube_G, cube_C, cube_B, cube_A, cube_E</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip9 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip94911a84-9d36-4cdb-89c0-25a8691c9369">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip10)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 839.10 368.36 L 850.19 338.97"/>
-<title>Segment proj_l</title>
-<desc>Segment proj_l: Segment proj_D, proj_H</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip10 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clipdd93f46d-6654-4325-a24c-c074aaf26942">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip11)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 850.19 338.97 L 879.06 313.57"/>
-<title>Segment proj_m</title>
-<desc>Segment proj_m: Segment proj_H, proj_G</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip11 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip5d6e64e6-c729-454c-b34b-72219d3047b4">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip12)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 879.06 313.57 L 868.32 342.16"/>
-<title>Segment proj_n</title>
-<desc>Segment proj_n: Segment proj_G, proj_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip12 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip37b2e9b4-7d8c-4d9d-9496-62a9267a7446">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip13)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 868.32 342.16 L 839.10 368.36"/>
-<title>Segment proj_p</title>
-<desc>Segment proj_p: Segment proj_C, proj_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip13 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip2bf3ff9d-87a9-48a7-b74d-812a159c1c8b">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip14)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 879.06 313.57 L 876.98 368.51"/>
-<title>Segment proj_q</title>
-<desc>Segment proj_q: Segment proj_G, proj_F</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip14 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip923c067f-be10-4c1f-a551-e99e527dc4fa">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip15)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 876.98 368.51 L 866.41 396.80"/>
-<title>Segment proj_r</title>
-<desc>Segment proj_r: Segment proj_F, proj_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip15 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip377f988e-53aa-45b3-a978-d47d5c67bc5a">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip16)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 866.41 396.80 L 868.32 342.16"/>
-<title>Segment proj_s</title>
-<desc>Segment proj_s: Segment proj_B, proj_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip16 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip62081bbf-ea72-45a6-a16a-3e01767749d3">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip17)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 866.41 396.80 L 837.62 423.92"/>
-<title>Segment proj_t</title>
-<desc>Segment proj_t: Segment proj_B, proj_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip17 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip91067e64-5dc4-49e2-89e9-17900c7912f2">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip18)">
-<g stroke-linejoin="round" stroke-width="3.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 837.62 423.92 L 839.10 368.36"/>
-<title>Segment proj_f</title>
-<desc>Segment proj_f: Segment proj_A, proj_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip18 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clipa30b7046-3fc2-468e-a2ea-a7812fae2f65">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip19)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 558.62 399.98 L 592.89 374.38"/>
-<title>Segment cube_l</title>
-<desc>Segment cube_l: Segment cube_H, cube_G</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip19 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip553fc5d3-6784-431e-a029-cd7db992e588">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip20)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 592.89 374.38 L 643.12 389.01"/>
-<title>Segment cube_k</title>
-<desc>Segment cube_k: Segment cube_G, cube_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip20 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip902c88aa-0396-4230-8c63-33c302ca693f">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip21)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 643.12 389.01 L 644.77 440.88"/>
-<title>Segment cube_n</title>
-<desc>Segment cube_n: Segment cube_C, cube_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip21 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip5d7b82a1-baff-4994-96eb-b2f815d5b626">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip22)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 644.77 440.88 L 611.81 468.01"/>
-<title>Segment cube_o</title>
-<desc>Segment cube_o: Segment cube_B, cube_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip22 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip2434be2c-61c5-443f-b171-40bc7d234a85">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip23)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 611.81 468.01 L 561.61 452.19"/>
-<title>Segment cube_p</title>
-<desc>Segment cube_p: Segment cube_A, cube_E</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip23 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip81302434-80d1-4b96-a7d0-4ef35d5fe7f6">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip24)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 561.61 452.19 L 558.62 399.98"/>
-<title>Segment cube_m</title>
-<desc>Segment cube_m: Segment cube_E, cube_H</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip24 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip2d2ec573-1937-494c-8087-48c9ad413b92">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip25)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 558.62 399.98 L 609.59 415.32"/>
-<title>Segment cube_j</title>
-<desc>Segment cube_j: Segment cube_H, cube_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip25 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip02f312e8-736d-42db-a805-88be0d249bab">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip26)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 609.59 415.32 L 643.12 389.01"/>
-<title>Segment cube_i</title>
-<desc>Segment cube_i: Segment cube_D, cube_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip26 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip5f2f3d95-8809-4524-9019-aa4ca445fa78">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip27)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 609.59 415.32 L 611.81 468.01"/>
-<title>Segment cube_q</title>
-<desc>Segment cube_q: Segment cube_D, cube_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip27 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clipfa96a558-3b17-4511-b9ed-da0788b4b87e">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip28)">
-<g stroke-linejoin="round" stroke-width="2.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 429.30 169.69 L 1069.3 169.69"/>
-<title>Segment edge_a</title>
-<desc>Segment edge_a: Segment edge_C, Export_2</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip28 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clipc0e68bb5-7ed9-49db-9193-1f7ab34544ee">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip29)">
-<g stroke-linejoin="round" stroke-width="2.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 429.30 169.69 L 429.30 649.69"/>
-<title>Segment edge_d</title>
-<desc>Segment edge_d: Segment edge_C, Export_1</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip29 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clipc285be81-156b-44fe-9130-ab3b14f84115">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip30)">
-<g stroke-linejoin="round" stroke-width="2.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 429.30 649.69 L 1069.3 649.69"/>
-<title>Segment edge_c</title>
-<desc>Segment edge_c: Segment Export_1, edge_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip30 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clipf64bdae6-8c0c-46ae-841d-24d93636d23c">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip31)">
-<g stroke-linejoin="round" stroke-width="2.0000" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 1069.3 649.69 L 1069.3 169.69"/>
-<title>Segment edge_b</title>
-<desc>Segment edge_b: Segment edge_D, Export_2</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip31 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip0c6cae57-c9d3-4abb-8846-f4c9572a2cc5">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip32)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 1039.4 425.96 L 645.46 318.67"/>
-<title>Segment base_d</title>
-<desc>Segment base_d: Segment base_B, base_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip32 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clipc63948e0-e5a4-43d8-85cf-fc9699391e38">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip33)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 799.56 305.29 L 918.69 208.02"/>
-<title>Segment pane_a</title>
-<desc>Segment pane_a: Segment pane_D, pane_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip33 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip1dc0915e-4480-423f-873a-58a73a2c8a9c">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip34)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 918.69 208.02 L 908.42 422.00"/>
-<title>Segment pane_b</title>
-<desc>Segment pane_b: Segment pane_C, pane_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip34 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clipfe79778c-bc5d-4213-8380-f7771d4a4015">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip35)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 908.42 422.00 L 796.21 534.21"/>
-<title>Segment pane_c</title>
-<desc>Segment pane_c: Segment pane_B, pane_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip35 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip87088da9-48ad-45f6-aa1a-ed3afc6399b6">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip36)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 796.21 534.21 L 799.56 305.29"/>
-<title>Segment pane_d</title>
-<desc>Segment pane_d: Segment pane_A, pane_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip36 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip3453fd61-ed9f-416a-af7e-2305aa602a0d">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip37)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 561.86 456.60 L 565.78 453.51"/>
-<title>Segment shad_m</title>
-<desc>Segment shad_m: Segment shad_H, shad_I</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip37 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip0ff39f49-0788-473e-9a79-96dce8bf5ef3">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip38)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 561.86 456.60 L 611.99 472.46"/>
-<title>Segment shad_n</title>
-<desc>Segment shad_n: Segment shad_H, shad_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip38 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip051dc6de-8852-4cab-be8a-4cd77a2ed511">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip39)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 611.99 472.46 L 644.91 445.26"/>
-<title>Segment shad_o</title>
-<desc>Segment shad_o: Segment shad_D, shad_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip39 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clipd1ae2241-9fb0-45c4-be3e-8a417d704f65">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip40)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 644.91 445.26 L 640.93 444.04"/>
-<title>Segment shad_p</title>
-<desc>Segment shad_p: Segment shad_C, shad_J</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip40 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clipdeafabc9-4f34-442f-af66-2d2b8549ca86">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip41)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 643.12 389.01 L 868.32 342.16"/>
-<title>Segment vect_c</title>
-<desc>Segment vect_c: Segment cube_C, proj_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip41 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip67ce25d7-af1d-4928-88ec-a82098641954">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip42)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 644.77 440.88 L 866.41 396.80"/>
-<title>Segment vect_d</title>
-<desc>Segment vect_d: Segment cube_B, proj_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip42 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip707ef261-6a51-4f13-96df-8652219ae8de">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip43)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 611.81 468.01 L 837.62 423.92"/>
-<title>Segment vect_e</title>
-<desc>Segment vect_e: Segment cube_A, proj_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip43 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip17a12a42-97f2-45cb-9e83-5e5ecf89b0c7">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip44)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 643.97 415.88 L 876.98 368.51"/>
-<title>Segment vect_j</title>
-<desc>Segment vect_j: Segment vect_A, proj_F</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip44 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip4b3a6a64-4bb6-4541-bbff-e7d5980f8a7f">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip45)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 558.62 399.98 L 850.19 338.97"/>
-<title>Segment vect_u</title>
-<desc>Segment vect_u: Segment cube_H, proj_H</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip45 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clipec626e84-b45b-4eea-91af-4851e035358e">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip46)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 592.89 374.38 L 879.06 313.57"/>
-<title>Segment vect_v</title>
-<desc>Segment vect_v: Segment cube_G, proj_G</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip46 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clipb94bb21d-18f8-43df-b1c9-db856532e713">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip47)">
-<g stroke-linejoin="round" stroke-dasharray="1.0000,3.0000" stroke-linecap="butt" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 609.59 415.32 L 839.10 368.36"/>
-<title>Segment vect_w</title>
-<desc>Segment vect_w: Segment cube_D, proj_D</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip47 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip2a02f3a2-8e31-4f05-851c-fdcaabf9fae4">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip48)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 882.32 604.49 L 1039.4 425.96"/>
-<title>Segment base_c</title>
-<desc>Segment base_c: Segment base_A, base_B</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip48 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip2011c00b-4d36-40f4-a66c-bd3e40b7cc0b">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip49)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 449.73 462.58 L 882.32 604.49"/>
-<title>Segment base_b</title>
-<desc>Segment base_b: Segment base_D, base_A</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip49 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip9f5ce5b8-517b-475e-b61f-4f20443b9a2b">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip50)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 449.73 462.58 L 645.46 318.67"/>
-<title>Segment base_a</title>
-<desc>Segment base_a: Segment base_D, base_C</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip50 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clipf110d7e2-2dfe-4a93-ad43-6fc21e31b9ef">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip51)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 469.95 213.88 L 472.33 214.23 Q 471.64 216.16 470.25 217.18 Q 468.86 218.20 466.98 218.20 Q 464.89 218.20 463.70 216.94 Q 462.52 215.67 462.52 213.27 Q 462.52 211.31 463.31 209.69 Q 464.11 208.06 465.52 207.20 Q 466.92 206.34 468.58 206.34 Q 470.44 206.34 471.59 207.34 Q 472.73 208.34 472.94 210.06 L 470.67 210.28 Q 470.48 209.28 469.95 208.83 Q 469.42 208.38 468.53 208.38 Q 467.55 208.38 466.70 208.97 Q 465.86 209.56 465.35 210.83 Q 464.84 212.09 464.84 213.34 Q 464.84 214.72 465.50 215.47 Q 466.16 216.22 467.14 216.22 Q 468.06 216.22 468.82 215.62 Q 469.58 215.03 469.95 213.88 z M 480.71 215.47 L 476.18 215.47 L 474.80 218.00 L 472.37 218.00 L 478.85 206.55 L 481.48 206.55 L 483.34 218.00 L 481.10 218.00 L 480.71 215.47 z M 480.43 213.56 L 479.76 208.95 L 476.99 213.56 L 480.43 213.56 z M 484.75 218.00 L 487.16 206.55 L 491.06 206.55 Q 492.34 206.55 492.84 206.62 Q 493.69 206.73 494.27 207.09 Q 494.86 207.44 495.16 208.02 Q 495.47 208.61 495.47 209.33 Q 495.47 210.28 494.94 210.98 Q 494.41 211.67 493.30 212.03 Q 494.19 212.28 494.68 212.90 Q 495.17 213.52 495.17 214.30 Q 495.17 215.33 494.59 216.26 Q 494.00 217.19 492.97 217.59 Q 491.94 218.00 490.16 218.00 L 484.75 218.00 z M 488.53 211.17 L 490.33 211.17 Q 491.55 211.17 492.08 211.00 Q 492.61 210.83 492.88 210.44 Q 493.14 210.05 493.14 209.59 Q 493.14 209.16 492.89 208.88 Q 492.64 208.59 492.17 208.50 Q 491.92 208.45 490.94 208.45 L 489.11 208.45 L 488.53 211.17 z M 487.50 216.16 L 489.77 216.16 Q 491.20 216.16 491.69 215.97 Q 492.17 215.78 492.47 215.36 Q 492.77 214.94 492.77 214.47 Q 492.77 213.91 492.34 213.53 Q 491.92 213.16 490.94 213.16 L 488.12 213.16 L 487.50 216.16 z M 496.23 218.00 L 498.62 206.55 L 500.98 206.55 L 498.59 218.00 L 496.23 218.00 z M 509.92 218.00 L 507.73 218.00 L 504.64 210.30 L 503.03 218.00 L 500.83 218.00 L 503.22 206.55 L 505.42 206.55 L 508.53 214.20 L 510.12 206.55 L 512.31 206.55 L 509.92 218.00 z M 512.32 218.00 L 514.71 206.55 L 523.21 206.55 L 522.80 208.45 L 516.68 208.45 L 516.13 211.06 L 522.05 211.06 L 521.66 212.97 L 515.73 212.97 L 515.01 216.08 L 521.68 216.08 L 521.27 218.00 L 512.32 218.00 z M 527.98 218.00 L 525.62 218.00 L 527.62 208.45 L 524.26 208.45 L 524.66 206.55 L 533.68 206.55 L 533.29 208.45 L 529.98 208.45 L 527.98 218.00 z"/>
-<title>CABINET&#xa;(OBLIQUE)</title>
-<desc>text1 = “CABINET&#xa;(OBLIQUE)”</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip51 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip7ee5f919-302e-46cc-8b90-76b8838764a1">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip52)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 464.84 245.38 L 463.31 245.38 Q 462.67 243.88 462.37 242.34 Q 462.06 240.81 462.06 239.55 Q 462.06 237.95 462.57 236.34 Q 463.08 234.73 464.14 233.08 Q 464.80 232.02 466.27 230.34 L 467.97 230.34 Q 466.48 232.09 465.67 233.63 Q 464.86 235.17 464.46 236.98 Q 464.06 238.80 464.06 240.53 Q 464.06 241.70 464.24 242.82 Q 464.42 243.94 464.84 245.38 z M 467.73 237.50 Q 467.73 236.48 468.03 235.36 Q 468.44 233.86 469.25 232.75 Q 470.06 231.64 471.30 230.99 Q 472.55 230.34 474.14 230.34 Q 476.27 230.34 477.57 231.66 Q 478.88 232.98 478.88 235.17 Q 478.88 236.98 478.02 238.68 Q 477.17 240.38 475.71 241.29 Q 474.25 242.20 472.41 242.20 Q 470.81 242.20 469.73 241.48 Q 468.64 240.75 468.19 239.67 Q 467.73 238.59 467.73 237.50 z M 470.06 237.45 Q 470.06 238.64 470.78 239.44 Q 471.50 240.23 472.67 240.23 Q 473.62 240.23 474.50 239.60 Q 475.38 238.97 475.95 237.70 Q 476.53 236.42 476.53 235.20 Q 476.53 233.86 475.80 233.09 Q 475.08 232.31 473.95 232.31 Q 472.22 232.31 471.14 233.92 Q 470.06 235.53 470.06 237.45 z M 479.41 242.00 L 481.82 230.55 L 485.73 230.55 Q 487.01 230.55 487.51 230.62 Q 488.35 230.73 488.94 231.09 Q 489.52 231.44 489.83 232.02 Q 490.13 232.61 490.13 233.33 Q 490.13 234.28 489.60 234.98 Q 489.07 235.67 487.96 236.03 Q 488.85 236.28 489.34 236.90 Q 489.84 237.52 489.84 238.30 Q 489.84 239.33 489.25 240.26 Q 488.66 241.19 487.63 241.59 Q 486.60 242.00 484.82 242.00 L 479.41 242.00 z M 483.20 235.17 L 484.99 235.17 Q 486.21 235.17 486.74 235.00 Q 487.27 234.83 487.54 234.44 Q 487.80 234.05 487.80 233.59 Q 487.80 233.16 487.55 232.88 Q 487.30 232.59 486.84 232.50 Q 486.59 232.45 485.60 232.45 L 483.77 232.45 L 483.20 235.17 z M 482.16 240.16 L 484.43 240.16 Q 485.87 240.16 486.35 239.97 Q 486.84 239.78 487.13 239.36 Q 487.43 238.94 487.43 238.47 Q 487.43 237.91 487.01 237.53 Q 486.59 237.16 485.60 237.16 L 482.79 237.16 L 482.16 240.16 z M 491.05 242.00 L 493.45 230.55 L 495.80 230.55 L 493.81 240.08 L 499.64 240.08 L 499.23 242.00 L 491.05 242.00 z M 500.66 242.00 L 503.05 230.55 L 505.41 230.55 L 503.02 242.00 L 500.66 242.00 z M 512.97 241.77 Q 512.42 241.98 511.84 242.09 Q 511.25 242.20 510.62 242.20 Q 508.53 242.20 507.24 240.89 Q 505.95 239.58 505.95 237.47 Q 505.95 235.75 506.76 233.98 Q 507.56 232.22 509.02 231.28 Q 510.48 230.34 512.36 230.34 Q 514.48 230.34 515.79 231.66 Q 517.09 232.98 517.09 235.17 Q 517.09 236.84 516.39 238.38 Q 515.69 239.91 514.52 240.86 Q 515.27 241.59 516.09 242.06 L 514.98 243.53 Q 513.89 243.00 512.97 241.77 z M 513.17 239.22 Q 513.88 238.50 514.31 237.36 Q 514.75 236.22 514.75 235.22 Q 514.75 233.86 514.02 233.09 Q 513.30 232.31 512.17 232.31 Q 511.39 232.31 510.73 232.67 Q 510.08 233.03 509.53 233.70 Q 508.98 234.38 508.63 235.37 Q 508.28 236.36 508.28 237.34 Q 508.28 238.69 509.02 239.45 Q 509.77 240.22 510.91 240.22 Q 511.23 240.22 511.58 240.17 Q 511.70 240.16 511.73 240.13 Q 511.77 240.11 511.77 240.06 Q 511.77 240.00 511.53 239.78 Q 511.03 239.31 510.48 239.11 L 511.34 237.80 Q 512.39 238.33 513.17 239.22 z M 520.05 230.55 L 522.40 230.55 L 521.10 236.77 L 520.79 238.30 Q 520.76 238.48 520.76 238.66 Q 520.76 239.34 521.25 239.78 Q 521.74 240.22 522.70 240.22 Q 523.54 240.22 524.09 239.90 Q 524.65 239.58 524.95 238.95 Q 525.26 238.31 525.57 236.80 L 526.88 230.55 L 529.24 230.55 L 527.93 236.81 Q 527.52 238.78 526.98 239.83 Q 526.45 240.88 525.35 241.54 Q 524.26 242.20 522.59 242.20 Q 520.59 242.20 519.52 241.22 Q 518.46 240.23 518.46 238.69 Q 518.46 238.38 518.51 238.00 Q 518.54 237.75 518.79 236.58 L 520.05 230.55 z M 529.20 242.00 L 531.59 230.55 L 540.09 230.55 L 539.69 232.45 L 533.56 232.45 L 533.02 235.06 L 538.94 235.06 L 538.55 236.97 L 532.61 236.97 L 531.89 240.08 L 538.56 240.08 L 538.16 242.00 L 529.20 242.00 z M 541.11 230.34 L 542.62 230.34 Q 543.27 231.83 543.58 233.36 Q 543.89 234.89 543.89 236.16 Q 543.89 237.75 543.38 239.36 Q 542.86 240.97 541.81 242.64 Q 541.14 243.70 539.67 245.38 L 537.97 245.38 Q 539.45 243.62 540.27 242.09 Q 541.08 240.55 541.48 238.73 Q 541.88 236.92 541.88 235.17 Q 541.88 234.00 541.70 232.89 Q 541.53 231.78 541.11 230.34 z"/>
-<title>CABINET&#xa;(OBLIQUE)</title>
-<desc>text1 = “CABINET&#xa;(OBLIQUE)”</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip52 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clipb63029b8-615f-4d25-9731-1b1999b5dc2c">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip53)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#ffffff">
-  <path d="M 1223.0 227.00 L 1223.0 258.00 C 1223.0 260.21 1224.8 262.00 1227.0 262.00 L 1466.0 262.00 C 1468.2 262.00 1470.0 260.21 1470.0 258.00 L 1470.0 227.00 C 1470.0 224.79 1468.2 223.00 1466.0 223.00 L 1227.0 223.00 C 1224.8 223.00 1223.0 224.79 1223.0 227.00 z"/>
-<title>Button button2</title>
-<desc>button2</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip53 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip6882d905-094e-48ad-9080-e73514571e88">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip54)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 1223.5 227.50 L 1223.5 258.50 C 1223.5 260.71 1225.3 262.50 1227.5 262.50 L 1466.5 262.50 C 1468.7 262.50 1470.5 260.71 1470.5 258.50 L 1470.5 227.50 C 1470.5 225.29 1468.7 223.50 1466.5 223.50 L 1227.5 223.50 C 1225.3 223.50 1223.5 225.29 1223.5 227.50 z"/>
-<title>Button button2</title>
-<desc>button2</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip54 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clip6eddcf52-6d27-49e1-b32c-0e6aa25326d2">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip55)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 1246.1 245.97 L 1248.4 246.55 Q 1247.7 249.34 1245.8 250.82 Q 1244.0 252.30 1241.3 252.30 Q 1238.5 252.30 1236.8 251.16 Q 1235.0 250.03 1234.1 247.88 Q 1233.2 245.73 1233.2 243.28 Q 1233.2 240.59 1234.2 238.59 Q 1235.2 236.59 1237.1 235.56 Q 1239.0 234.53 1241.3 234.53 Q 1243.9 234.53 1245.6 235.84 Q 1247.4 237.16 1248.1 239.53 L 1245.9 240.06 Q 1245.2 238.19 1244.1 237.33 Q 1243.0 236.47 1241.3 236.47 Q 1239.3 236.47 1238.0 237.42 Q 1236.6 238.38 1236.1 239.97 Q 1235.5 241.56 1235.5 243.27 Q 1235.5 245.45 1236.2 247.09 Q 1236.8 248.73 1238.2 249.54 Q 1239.5 250.34 1241.1 250.34 Q 1243.0 250.34 1244.3 249.24 Q 1245.6 248.14 1246.1 245.97 z M 1250.9 252.00 L 1250.9 234.81 L 1253.0 234.81 L 1253.0 252.00 L 1250.9 252.00 z M 1256.3 237.25 L 1256.3 234.81 L 1258.4 234.81 L 1258.4 237.25 L 1256.3 237.25 z M 1256.3 252.00 L 1256.3 239.55 L 1258.4 239.55 L 1258.4 252.00 L 1256.3 252.00 z M 1269.7 247.44 L 1271.8 247.70 Q 1271.4 249.86 1270.0 251.07 Q 1268.6 252.28 1266.6 252.28 Q 1264.0 252.28 1262.5 250.61 Q 1260.9 248.94 1260.9 245.83 Q 1260.9 243.81 1261.6 242.30 Q 1262.3 240.78 1263.6 240.02 Q 1265.0 239.27 1266.6 239.27 Q 1268.6 239.27 1269.9 240.30 Q 1271.2 241.33 1271.6 243.20 L 1269.5 243.53 Q 1269.2 242.27 1268.5 241.63 Q 1267.7 241.00 1266.7 241.00 Q 1265.1 241.00 1264.1 242.15 Q 1263.1 243.30 1263.1 245.77 Q 1263.1 248.27 1264.1 249.41 Q 1265.0 250.55 1266.6 250.55 Q 1267.8 250.55 1268.6 249.78 Q 1269.5 249.02 1269.7 247.44 z M 1273.6 252.00 L 1273.6 234.81 L 1275.7 234.81 L 1275.7 244.61 L 1280.7 239.55 L 1283.4 239.55 L 1278.7 244.17 L 1283.9 252.00 L 1281.3 252.00 L 1277.2 245.64 L 1275.7 247.06 L 1275.7 252.00 L 1273.6 252.00 z M 1296.9 252.00 L 1296.9 236.84 L 1291.2 236.84 L 1291.2 234.81 L 1304.9 234.81 L 1304.9 236.84 L 1299.2 236.84 L 1299.2 252.00 L 1296.9 252.00 z M 1309.2 252.00 L 1305.4 239.55 L 1307.6 239.55 L 1309.6 246.73 L 1310.3 249.41 Q 1310.3 249.20 1310.9 246.84 L 1312.9 239.55 L 1315.1 239.55 L 1316.9 246.77 L 1317.6 249.16 L 1318.3 246.75 L 1320.4 239.55 L 1322.5 239.55 L 1318.6 252.00 L 1316.4 252.00 L 1314.4 244.55 L 1313.9 242.42 L 1311.4 252.00 L 1309.2 252.00 z M 1324.2 237.25 L 1324.2 234.81 L 1326.4 234.81 L 1326.4 237.25 L 1324.2 237.25 z M 1324.2 252.00 L 1324.2 239.55 L 1326.4 239.55 L 1326.4 252.00 L 1324.2 252.00 z M 1337.7 247.44 L 1339.8 247.70 Q 1339.4 249.86 1338.0 251.07 Q 1336.6 252.28 1334.6 252.28 Q 1332.0 252.28 1330.5 250.61 Q 1328.9 248.94 1328.9 245.83 Q 1328.9 243.81 1329.6 242.30 Q 1330.3 240.78 1331.6 240.02 Q 1333.0 239.27 1334.6 239.27 Q 1336.6 239.27 1337.9 240.30 Q 1339.2 241.33 1339.6 243.20 L 1337.5 243.53 Q 1337.2 242.27 1336.5 241.63 Q 1335.7 241.00 1334.7 241.00 Q 1333.1 241.00 1332.1 242.15 Q 1331.1 243.30 1331.1 245.77 Q 1331.1 248.27 1332.1 249.41 Q 1333.0 250.55 1334.6 250.55 Q 1335.8 250.55 1336.6 249.78 Q 1337.5 249.02 1337.7 247.44 z M 1350.1 247.98 L 1352.3 248.27 Q 1351.8 250.17 1350.4 251.23 Q 1349.0 252.28 1346.8 252.28 Q 1344.1 252.28 1342.5 250.60 Q 1340.9 248.92 1340.9 245.88 Q 1340.9 242.73 1342.5 241.00 Q 1344.1 239.27 1346.7 239.27 Q 1349.2 239.27 1350.8 240.97 Q 1352.3 242.67 1352.3 245.75 Q 1352.3 245.94 1352.3 246.31 L 1343.1 246.31 Q 1343.2 248.36 1344.2 249.45 Q 1345.3 250.55 1346.8 250.55 Q 1348.0 250.55 1348.8 249.94 Q 1349.6 249.33 1350.1 247.98 z M 1343.2 244.58 L 1350.1 244.58 Q 1350.0 243.02 1349.3 242.22 Q 1348.3 241.00 1346.7 241.00 Q 1345.3 241.00 1344.3 241.98 Q 1343.3 242.95 1343.2 244.58 z M 1366.2 250.11 L 1366.5 251.97 Q 1365.6 252.17 1364.9 252.17 Q 1363.8 252.17 1363.1 251.80 Q 1362.5 251.44 1362.2 250.84 Q 1362.0 250.25 1362.0 248.36 L 1362.0 241.19 L 1360.4 241.19 L 1360.4 239.55 L 1362.0 239.55 L 1362.0 236.47 L 1364.1 235.20 L 1364.1 239.55 L 1366.2 239.55 L 1366.2 241.19 L 1364.1 241.19 L 1364.1 248.47 Q 1364.1 249.38 1364.2 249.63 Q 1364.3 249.89 1364.6 250.04 Q 1364.8 250.19 1365.3 250.19 Q 1365.6 250.19 1366.2 250.11 z M 1367.5 245.78 Q 1367.5 242.31 1369.4 240.66 Q 1371.0 239.27 1373.3 239.27 Q 1375.9 239.27 1377.5 240.95 Q 1379.1 242.64 1379.1 245.59 Q 1379.1 248.00 1378.4 249.38 Q 1377.7 250.75 1376.3 251.52 Q 1374.9 252.28 1373.3 252.28 Q 1370.7 252.28 1369.1 250.60 Q 1367.5 248.92 1367.5 245.78 z M 1369.6 245.78 Q 1369.6 248.17 1370.7 249.36 Q 1371.7 250.55 1373.3 250.55 Q 1374.9 250.55 1375.9 249.35 Q 1377.0 248.16 1377.0 245.70 Q 1377.0 243.39 1375.9 242.20 Q 1374.9 241.02 1373.3 241.02 Q 1371.7 241.02 1370.7 242.20 Q 1369.6 243.39 1369.6 245.78 z M 1388.6 252.00 L 1388.6 234.81 L 1396.2 234.81 Q 1398.5 234.81 1399.7 235.28 Q 1400.9 235.75 1401.6 236.92 Q 1402.3 238.09 1402.3 239.50 Q 1402.3 241.33 1401.1 242.59 Q 1399.9 243.84 1397.5 244.19 Q 1398.4 244.61 1398.8 245.03 Q 1399.8 245.95 1400.7 247.33 L 1403.7 252.00 L 1400.9 252.00 L 1398.6 248.42 Q 1397.6 246.88 1396.9 246.05 Q 1396.3 245.23 1395.8 244.91 Q 1395.3 244.58 1394.8 244.45 Q 1394.4 244.38 1393.5 244.38 L 1390.8 244.38 L 1390.8 252.00 L 1388.6 252.00 z M 1390.8 242.41 L 1395.7 242.41 Q 1397.3 242.41 1398.2 242.08 Q 1399.0 241.75 1399.5 241.05 Q 1400.0 240.34 1400.0 239.50 Q 1400.0 238.28 1399.1 237.50 Q 1398.2 236.72 1396.3 236.72 L 1390.8 236.72 L 1390.8 242.41 z M 1414.1 247.98 L 1416.3 248.27 Q 1415.8 250.17 1414.4 251.23 Q 1413.0 252.28 1410.8 252.28 Q 1408.1 252.28 1406.5 250.60 Q 1404.9 248.92 1404.9 245.88 Q 1404.9 242.73 1406.5 241.00 Q 1408.1 239.27 1410.7 239.27 Q 1413.2 239.27 1414.8 240.97 Q 1416.4 242.67 1416.4 245.75 Q 1416.4 245.94 1416.4 246.31 L 1407.1 246.31 Q 1407.2 248.36 1408.2 249.45 Q 1409.3 250.55 1410.8 250.55 Q 1412.0 250.55 1412.8 249.94 Q 1413.6 249.33 1414.1 247.98 z M 1407.2 244.58 L 1414.1 244.58 Q 1414.0 243.02 1413.3 242.22 Q 1412.3 241.00 1410.7 241.00 Q 1409.3 241.00 1408.3 241.98 Q 1407.3 242.95 1407.2 244.58 z M 1418.1 248.28 L 1420.2 247.95 Q 1420.4 249.20 1421.2 249.88 Q 1422.0 250.55 1423.4 250.55 Q 1424.9 250.55 1425.6 249.95 Q 1426.3 249.36 1426.3 248.56 Q 1426.3 247.84 1425.6 247.44 Q 1425.2 247.16 1423.5 246.72 Q 1421.2 246.14 1420.3 245.71 Q 1419.4 245.28 1418.9 244.52 Q 1418.5 243.77 1418.5 242.86 Q 1418.5 242.03 1418.8 241.32 Q 1419.2 240.61 1419.9 240.14 Q 1420.4 239.78 1421.2 239.52 Q 1422.1 239.27 1423.0 239.27 Q 1424.5 239.27 1425.6 239.69 Q 1426.7 240.11 1427.2 240.84 Q 1427.8 241.56 1428.0 242.77 L 1425.9 243.05 Q 1425.8 242.08 1425.1 241.54 Q 1424.4 241.00 1423.2 241.00 Q 1421.7 241.00 1421.1 241.48 Q 1420.5 241.97 1420.5 242.61 Q 1420.5 243.02 1420.8 243.34 Q 1421.0 243.69 1421.6 243.91 Q 1421.9 244.03 1423.4 244.45 Q 1425.7 245.05 1426.5 245.43 Q 1427.4 245.81 1427.9 246.54 Q 1428.4 247.27 1428.4 248.34 Q 1428.4 249.39 1427.8 250.33 Q 1427.2 251.27 1426.1 251.77 Q 1424.9 252.28 1423.4 252.28 Q 1421.0 252.28 1419.7 251.27 Q 1418.5 250.27 1418.1 248.28 z M 1431.0 237.25 L 1431.0 234.81 L 1433.1 234.81 L 1433.1 237.25 L 1431.0 237.25 z M 1431.0 252.00 L 1431.0 239.55 L 1433.1 239.55 L 1433.1 252.00 L 1431.0 252.00 z M 1435.2 252.00 L 1435.2 250.28 L 1443.1 241.19 Q 1441.7 241.27 1440.7 241.27 L 1435.6 241.27 L 1435.6 239.55 L 1445.8 239.55 L 1445.8 240.95 L 1439.1 248.84 L 1437.8 250.28 Q 1439.2 250.19 1440.4 250.19 L 1446.2 250.19 L 1446.2 252.00 L 1435.2 252.00 z M 1456.8 247.98 L 1459.0 248.27 Q 1458.5 250.17 1457.1 251.23 Q 1455.7 252.28 1453.5 252.28 Q 1450.8 252.28 1449.2 250.60 Q 1447.6 248.92 1447.6 245.88 Q 1447.6 242.73 1449.2 241.00 Q 1450.8 239.27 1453.4 239.27 Q 1455.9 239.27 1457.5 240.97 Q 1459.1 242.67 1459.1 245.75 Q 1459.1 245.94 1459.0 246.31 L 1449.8 246.31 Q 1449.9 248.36 1450.9 249.45 Q 1452.0 250.55 1453.5 250.55 Q 1454.7 250.55 1455.5 249.94 Q 1456.3 249.33 1456.8 247.98 z M 1449.9 244.58 L 1456.8 244.58 Q 1456.7 243.02 1456.0 242.22 Q 1455.0 241.00 1453.4 241.00 Q 1452.0 241.00 1451.0 241.98 Q 1450.0 242.95 1449.9 244.58 z"/>
-<title>Button button2</title>
-<desc>button2</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip55 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clipce448a06-2a08-44cd-a054-57218863da7c">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip56)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#ffffff">
-  <path d="M 1223.0 145.00 L 1223.0 176.00 C 1223.0 178.21 1224.8 180.00 1227.0 180.00 L 1438.0 180.00 C 1440.2 180.00 1442.0 178.21 1442.0 176.00 L 1442.0 145.00 C 1442.0 142.79 1440.2 141.00 1438.0 141.00 L 1227.0 141.00 C 1224.8 141.00 1223.0 142.79 1223.0 145.00 z"/>
-<title>Button button1</title>
-<desc>button1</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip56 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clipf9250522-8f2e-4a50-91a2-dcc4ed08f4d0">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip57)">
-<g stroke-linejoin="round" stroke-linecap="round" fill="none" stroke-opacity="1.0000" stroke="#000000">
-  <path d="M 1223.5 145.50 L 1223.5 176.50 C 1223.5 178.71 1225.3 180.50 1227.5 180.50 L 1438.5 180.50 C 1440.7 180.50 1442.5 178.71 1442.5 176.50 L 1442.5 145.50 C 1442.5 143.29 1440.7 141.50 1438.5 141.50 L 1227.5 141.50 C 1225.3 141.50 1223.5 143.29 1223.5 145.50 z"/>
-<title>Button button1</title>
-<desc>button1</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip57 -->
-</g> <!-- transform -->
-<g transform="matrix(1.0000, 0.0000, 0.0000, 1.0000, -429.30, -169.69)">
-<clipPath id="clipe30f0cb3-a9e0-455d-bf77-4de04f366265">
-  <path d="M 429.30 169.69 L 429.30 651.69 L 1071.3 651.69 L 1071.3 169.69 z"/>
-</clipPath>
-<g clip-path="url(#clip58)">
-<g fill-opacity="1.0000" fill-rule="nonzero" stroke="none" fill="#000000">
-  <path d="M 1246.1 163.97 L 1248.4 164.55 Q 1247.7 167.34 1245.8 168.82 Q 1244.0 170.30 1241.3 170.30 Q 1238.5 170.30 1236.8 169.16 Q 1235.0 168.03 1234.1 165.88 Q 1233.2 163.73 1233.2 161.28 Q 1233.2 158.59 1234.2 156.59 Q 1235.2 154.59 1237.1 153.56 Q 1239.0 152.53 1241.3 152.53 Q 1243.9 152.53 1245.6 153.84 Q 1247.4 155.16 1248.1 157.53 L 1245.9 158.06 Q 1245.2 156.19 1244.1 155.33 Q 1243.0 154.47 1241.3 154.47 Q 1239.3 154.47 1238.0 155.42 Q 1236.6 156.38 1236.1 157.97 Q 1235.5 159.56 1235.5 161.27 Q 1235.5 163.45 1236.2 165.09 Q 1236.8 166.73 1238.2 167.54 Q 1239.5 168.34 1241.1 168.34 Q 1243.0 168.34 1244.3 167.24 Q 1245.6 166.14 1246.1 163.97 z M 1250.9 170.00 L 1250.9 152.81 L 1253.0 152.81 L 1253.0 170.00 L 1250.9 170.00 z M 1256.3 155.25 L 1256.3 152.81 L 1258.4 152.81 L 1258.4 155.25 L 1256.3 155.25 z M 1256.3 170.00 L 1256.3 157.55 L 1258.4 157.55 L 1258.4 170.00 L 1256.3 170.00 z M 1269.7 165.44 L 1271.8 165.70 Q 1271.4 167.86 1270.0 169.07 Q 1268.6 170.28 1266.6 170.28 Q 1264.0 170.28 1262.5 168.61 Q 1260.9 166.94 1260.9 163.83 Q 1260.9 161.81 1261.6 160.30 Q 1262.3 158.78 1263.6 158.02 Q 1265.0 157.27 1266.6 157.27 Q 1268.6 157.27 1269.9 158.30 Q 1271.2 159.33 1271.6 161.20 L 1269.5 161.53 Q 1269.2 160.27 1268.5 159.63 Q 1267.7 159.00 1266.7 159.00 Q 1265.1 159.00 1264.1 160.15 Q 1263.1 161.30 1263.1 163.77 Q 1263.1 166.27 1264.1 167.41 Q 1265.0 168.55 1266.6 168.55 Q 1267.8 168.55 1268.6 167.78 Q 1269.5 167.02 1269.7 165.44 z M 1273.6 170.00 L 1273.6 152.81 L 1275.7 152.81 L 1275.7 162.61 L 1280.7 157.55 L 1283.4 157.55 L 1278.7 162.17 L 1283.9 170.00 L 1281.3 170.00 L 1277.2 163.64 L 1275.7 165.06 L 1275.7 170.00 L 1273.6 170.00 z M 1296.9 168.11 L 1297.2 169.97 Q 1296.3 170.17 1295.6 170.17 Q 1294.4 170.17 1293.8 169.80 Q 1293.1 169.44 1292.9 168.84 Q 1292.6 168.25 1292.6 166.36 L 1292.6 159.19 L 1291.1 159.19 L 1291.1 157.55 L 1292.6 157.55 L 1292.6 154.47 L 1294.7 153.20 L 1294.7 157.55 L 1296.9 157.55 L 1296.9 159.19 L 1294.7 159.19 L 1294.7 166.47 Q 1294.7 167.38 1294.8 167.63 Q 1295.0 167.89 1295.2 168.04 Q 1295.5 168.19 1295.9 168.19 Q 1296.3 168.19 1296.9 168.11 z M 1298.1 163.78 Q 1298.1 160.31 1300.1 158.66 Q 1301.7 157.27 1304.0 157.27 Q 1306.5 157.27 1308.2 158.95 Q 1309.8 160.64 1309.8 163.59 Q 1309.8 166.00 1309.1 167.38 Q 1308.3 168.75 1307.0 169.52 Q 1305.6 170.28 1304.0 170.28 Q 1301.3 170.28 1299.7 168.60 Q 1298.1 166.92 1298.1 163.78 z M 1300.3 163.78 Q 1300.3 166.17 1301.3 167.36 Q 1302.4 168.55 1304.0 168.55 Q 1305.5 168.55 1306.6 167.35 Q 1307.6 166.16 1307.6 163.70 Q 1307.6 161.39 1306.6 160.20 Q 1305.5 159.02 1304.0 159.02 Q 1302.4 159.02 1301.3 160.20 Q 1300.3 161.39 1300.3 163.78 z M 1319.2 170.00 L 1319.2 152.81 L 1325.7 152.81 Q 1327.4 152.81 1328.3 152.98 Q 1329.6 153.19 1330.4 153.78 Q 1331.3 154.38 1331.8 155.45 Q 1332.3 156.52 1332.3 157.78 Q 1332.3 159.98 1330.9 161.50 Q 1329.5 163.02 1325.9 163.02 L 1321.5 163.02 L 1321.5 170.00 L 1319.2 170.00 z M 1321.5 160.98 L 1325.9 160.98 Q 1328.1 160.98 1329.0 160.16 Q 1330.0 159.34 1330.0 157.86 Q 1330.0 156.78 1329.4 156.02 Q 1328.9 155.25 1328.0 155.00 Q 1327.4 154.84 1325.9 154.84 L 1321.5 154.84 L 1321.5 160.98 z M 1334.9 170.00 L 1334.9 152.81 L 1337.0 152.81 L 1337.0 170.00 L 1334.9 170.00 z M 1339.5 163.78 Q 1339.5 160.31 1341.4 158.66 Q 1343.0 157.27 1345.3 157.27 Q 1347.9 157.27 1349.5 158.95 Q 1351.1 160.64 1351.1 163.59 Q 1351.1 166.00 1350.4 167.38 Q 1349.7 168.75 1348.3 169.52 Q 1347.0 170.28 1345.3 170.28 Q 1342.7 170.28 1341.1 168.60 Q 1339.5 166.92 1339.5 163.78 z M 1341.7 163.78 Q 1341.7 166.17 1342.7 167.36 Q 1343.7 168.55 1345.3 168.55 Q 1346.9 168.55 1347.9 167.35 Q 1349.0 166.16 1349.0 163.70 Q 1349.0 161.39 1347.9 160.20 Q 1346.9 159.02 1345.3 159.02 Q 1343.7 159.02 1342.7 160.20 Q 1341.7 161.39 1341.7 163.78 z M 1358.2 168.11 L 1358.5 169.97 Q 1357.6 170.17 1356.9 170.17 Q 1355.8 170.17 1355.2 169.80 Q 1354.5 169.44 1354.3 168.84 Q 1354.0 168.25 1354.0 166.36 L 1354.0 159.19 L 1352.5 159.19 L 1352.5 157.55 L 1354.0 157.55 L 1354.0 154.47 L 1356.1 153.20 L 1356.1 157.55 L 1358.2 157.55 L 1358.2 159.19 L 1356.1 159.19 L 1356.1 166.47 Q 1356.1 167.38 1356.2 167.63 Q 1356.3 167.89 1356.6 168.04 Q 1356.8 168.19 1357.3 168.19 Q 1357.6 168.19 1358.2 168.11 z M 1367.2 170.00 L 1367.2 152.81 L 1373.7 152.81 Q 1375.4 152.81 1376.3 152.98 Q 1377.6 153.19 1378.4 153.78 Q 1379.3 154.38 1379.8 155.45 Q 1380.3 156.52 1380.3 157.78 Q 1380.3 159.98 1378.9 161.50 Q 1377.5 163.02 1373.9 163.02 L 1369.5 163.02 L 1369.5 170.00 L 1367.2 170.00 z M 1369.5 160.98 L 1373.9 160.98 Q 1376.1 160.98 1377.1 160.16 Q 1378.0 159.34 1378.0 157.86 Q 1378.0 156.78 1377.4 156.02 Q 1376.9 155.25 1376.0 155.00 Q 1375.4 154.84 1373.9 154.84 L 1369.5 154.84 L 1369.5 160.98 z M 1382.2 163.78 Q 1382.2 160.31 1384.1 158.66 Q 1385.7 157.27 1388.0 157.27 Q 1390.6 157.27 1392.2 158.95 Q 1393.8 160.64 1393.8 163.59 Q 1393.8 166.00 1393.1 167.38 Q 1392.4 168.75 1391.0 169.52 Q 1389.6 170.28 1388.0 170.28 Q 1385.4 170.28 1383.8 168.60 Q 1382.2 166.92 1382.2 163.78 z M 1384.3 163.78 Q 1384.3 166.17 1385.4 167.36 Q 1386.4 168.55 1388.0 168.55 Q 1389.6 168.55 1390.6 167.35 Q 1391.7 166.16 1391.7 163.70 Q 1391.7 161.39 1390.6 160.20 Q 1389.6 159.02 1388.0 159.02 Q 1386.4 159.02 1385.4 160.20 Q 1384.3 161.39 1384.3 163.78 z M 1396.3 155.25 L 1396.3 152.81 L 1398.4 152.81 L 1398.4 155.25 L 1396.3 155.25 z M 1396.3 170.00 L 1396.3 157.55 L 1398.4 157.55 L 1398.4 170.00 L 1396.3 170.00 z M 1401.6 170.00 L 1401.6 157.55 L 1403.5 157.55 L 1403.5 159.33 Q 1404.9 157.27 1407.5 157.27 Q 1408.6 157.27 1409.6 157.67 Q 1410.5 158.08 1411.0 158.73 Q 1411.4 159.39 1411.6 160.30 Q 1411.8 160.88 1411.8 162.34 L 1411.8 170.00 L 1409.7 170.00 L 1409.7 162.42 Q 1409.7 161.14 1409.4 160.50 Q 1409.2 159.86 1408.5 159.48 Q 1407.9 159.09 1407.1 159.09 Q 1405.7 159.09 1404.7 159.95 Q 1403.7 160.81 1403.7 163.20 L 1403.7 170.00 L 1401.6 170.00 z M 1419.6 168.11 L 1419.9 169.97 Q 1419.0 170.17 1418.3 170.17 Q 1417.2 170.17 1416.5 169.80 Q 1415.9 169.44 1415.6 168.84 Q 1415.4 168.25 1415.4 166.36 L 1415.4 159.19 L 1413.8 159.19 L 1413.8 157.55 L 1415.4 157.55 L 1415.4 154.47 L 1417.5 153.20 L 1417.5 157.55 L 1419.6 157.55 L 1419.6 159.19 L 1417.5 159.19 L 1417.5 166.47 Q 1417.5 167.38 1417.6 167.63 Q 1417.7 167.89 1418.0 168.04 Q 1418.2 168.19 1418.7 168.19 Q 1419.0 168.19 1419.6 168.11 z M 1420.8 166.28 L 1422.9 165.95 Q 1423.1 167.20 1423.9 167.88 Q 1424.7 168.55 1426.1 168.55 Q 1427.6 168.55 1428.3 167.95 Q 1429.0 167.36 1429.0 166.56 Q 1429.0 165.84 1428.4 165.44 Q 1427.9 165.16 1426.2 164.72 Q 1423.9 164.14 1423.0 163.71 Q 1422.1 163.28 1421.6 162.52 Q 1421.2 161.77 1421.2 160.86 Q 1421.2 160.03 1421.6 159.32 Q 1421.9 158.61 1422.6 158.14 Q 1423.1 157.78 1423.9 157.52 Q 1424.8 157.27 1425.7 157.27 Q 1427.2 157.27 1428.3 157.69 Q 1429.4 158.11 1430.0 158.84 Q 1430.5 159.56 1430.7 160.77 L 1428.6 161.05 Q 1428.5 160.08 1427.8 159.54 Q 1427.1 159.00 1425.9 159.00 Q 1424.4 159.00 1423.8 159.48 Q 1423.2 159.97 1423.2 160.61 Q 1423.2 161.02 1423.5 161.34 Q 1423.7 161.69 1424.3 161.91 Q 1424.6 162.03 1426.1 162.45 Q 1428.4 163.05 1429.3 163.43 Q 1430.1 163.81 1430.6 164.54 Q 1431.2 165.27 1431.2 166.34 Q 1431.2 167.39 1430.5 168.33 Q 1429.9 169.27 1428.8 169.77 Q 1427.6 170.28 1426.1 170.28 Q 1423.7 170.28 1422.4 169.27 Q 1421.2 168.27 1420.8 166.28 z"/>
-<title>Button button1</title>
-<desc>button1</desc>
-
-</g> <!-- drawing style -->
-</g> <!-- clip58 -->
-</g> <!-- transform -->
-</g><!-- layer0 -->
-</g> <!-- default stroke -->
-
-
-</svg> <!-- bounding box -->
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="368" height="481" version="1.1" viewBox="-640 -480 736 962" xmlns="http://www.w3.org/2000/svg">
+	<rect x="-639" y="-479" width="734" height="960" rx="0" ry="0" fill="#fff" fill-opacity=".071" stop-color="#000000" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" style="paint-order:stroke markers fill"/>
+	<g transform="translate(-1126 -681)" stroke-linecap="square" stroke-miterlimit="10">
+		<clipPath id="clip895d0752-d7f4-4970-a9e0-872ba779760d">
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip6)">
+			<g fill="#a0a0a0" fill-opacity=".25" fill-rule="evenodd">
+				<path d="m854 566 3.4-229 119-97-10 214z"/>
+				<title>Quadrilateral pane_{poly}</title>
+				<desc>Quadrilateral pane_{poly}: Polygon pane_A, pane_D, pane_C, pane_B</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip7)">
+			<g fill="#a0a0a0" fill-rule="evenodd">
+				<path d="m508 495 196-144 394 107-157 179z"/>
+				<title>Quadrilateral base_{poly}</title>
+				<desc>Quadrilateral base_{poly}: Polygon base_D, base_C, base_B, base_A</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip8)">
+			<g fill="#808080" fill-rule="evenodd">
+				<path d="m620 489 34-26 49 15-33 27z"/>
+				<title>Quadrilateral shad_{poly}</title>
+				<desc>Quadrilateral shad_{poly}: Polygon shad_E, shad_F, shad_B, shad_A</desc>
+			</g>
+		</g>
+		<clipPath id="clipd19dbc9b-dfa7-426f-a787-84815f69bb3b">
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip9)">
+			<g fill="#09f" fill-rule="evenodd">
+				<path d="m617 432 34-26 50 15 1.6 52-33 27-50-16z"/>
+				<title>Hexagon cube_{poly}</title>
+				<desc>Hexagon cube_{poly}: Polygon cube_H, cube_G, cube_C, cube_B, cube_A, cube_E</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip10)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+				<path d="m906 400 6.4-14"/>
+				<title>Segment proj_l</title>
+				<desc>Segment proj_l: Segment proj_D, proj_H</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip11)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+				<path d="m913 387 14-12"/>
+				<title>Segment proj_m</title>
+				<desc>Segment proj_m: Segment proj_H, proj_G</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip12)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+				<path d="m926 375-4.5 12"/>
+				<title>Segment proj_n</title>
+				<desc>Segment proj_n: Segment proj_G, proj_C</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip13)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+				<path d="m922 386-15 14"/>
+				<title>Segment proj_p</title>
+				<desc>Segment proj_p: Segment proj_C, proj_D</desc>
+			</g>
+		</g>
+		<clipPath id="clip28f864fb-05a4-4ca6-9013-206cbb022faf">
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip14)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+				<path d="m926 375-.91 26"/>
+				<title>Segment proj_q</title>
+				<desc>Segment proj_q: Segment proj_G, proj_F</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip15)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+				<path d="m925 401-4.5 15"/>
+				<title>Segment proj_r</title>
+				<desc>Segment proj_r: Segment proj_F, proj_B</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip16)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+				<path d="m921 416 .99-29"/>
+				<title>Segment proj_s</title>
+				<desc>Segment proj_s: Segment proj_B, proj_C</desc>
+			</g>
+		</g>
+		<clipPath id="clip6f20c4fc-e288-4d53-a77b-df040968f48f">
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip17)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+				<path d="m921 416-15 14"/>
+				<title>Segment proj_t</title>
+				<desc>Segment proj_t: Segment proj_B, proj_A</desc>
+			</g>
+		</g>
+		<clipPath id="clip931ce32e-d03a-474b-83c0-57a2053a17cc">
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip18)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+				<path d="m905 430 .87-30"/>
+				<title>Segment proj_f</title>
+				<desc>Segment proj_f: Segment proj_A, proj_D</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip23)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m940 637 157-179"/>
+				<title>Segment base_a</title>
+				<desc>Segment base_a: Segment base_A, base_B</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip24)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m1098 458-394-107"/>
+				<title>Segment base_c</title>
+				<desc>Segment base_c: Segment base_B, base_C</desc>
+			</g>
+		</g>
+		<clipPath id="clip8e7065e8-2737-4243-a6ea-05cd92b6536c">
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip25)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m620 489 50 16"/>
+				<title>Segment shad_m</title>
+				<desc>Segment shad_m: Segment shad_E, shad_A</desc>
+			</g>
+		</g>
+		<clipPath id="clip6fa24452-fba1-4de6-84c2-9e28b7a104ea">
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip26)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m670 505 33-27"/>
+				<title>Segment shad_n</title>
+				<desc>Segment shad_n: Segment shad_A, shad_B</desc>
+			</g>
+		</g>
+		<clipPath id="clip68c5f122-aeb7-476c-9684-2e7a0df0123c">
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip27)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m617 432 3 52"/>
+				<title>Segment cube_m</title>
+				<desc>Segment cube_m: Segment cube_H, cube_E</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip28)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m620 484 50 16"/>
+				<title>Segment cube_n</title>
+				<desc>Segment cube_n: Segment cube_E, cube_A</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip29)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m670 500 33-27"/>
+				<title>Segment cube_o</title>
+				<desc>Segment cube_o: Segment cube_A, cube_B</desc>
+			</g>
+		</g>
+		<clipPath id="clip0450dbaa-2aad-431d-9e8c-89451f7cd38c">
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip30)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m703 473-1.6-52"/>
+				<title>Segment cube_p</title>
+				<desc>Segment cube_p: Segment cube_B, cube_C</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip31)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m701 421-50-15"/>
+				<title>Segment cube_q</title>
+				<desc>Segment cube_q: Segment cube_C, cube_G</desc>
+			</g>
+		</g>
+		<clipPath id="clip32fa3cb6-a5e7-4ced-a964-c080e425c83a">
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip32)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m651 406-34 26"/>
+				<title>Segment cube_r</title>
+				<desc>Segment cube_r: Segment cube_G, cube_H</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip33)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m617 432 51 15"/>
+				<title>Segment cube_s</title>
+				<desc>Segment cube_s: Segment cube_H, cube_D</desc>
+			</g>
+		</g>
+		<clipPath id="clipda84d5e9-5820-4e46-a811-5620b96cdced">
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip34)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m668 447 2.2 53"/>
+				<title>Segment cube_t</title>
+				<desc>Segment cube_t: Segment cube_D, cube_A</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip35)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m668 447 34-26"/>
+				<title>Segment cube_l</title>
+				<desc>Segment cube_l: Segment cube_D, cube_C</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip36)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m620 489 3.9-3.1"/>
+				<title>Segment shad_o</title>
+				<desc>Segment shad_o: Segment shad_E, shad_L</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip37)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m699 476 4 1.2"/>
+				<title>Segment shad_p</title>
+				<desc>Segment shad_p: Segment shad_M, shad_B</desc>
+			</g>
+		</g>
+		<clipPath id="clip8f5a177f-6177-403e-b1a9-4e293f2c4b6e">
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip38)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m858 337 119-97"/>
+				<title>Segment pane_a</title>
+				<desc>Segment pane_a: Segment pane_D, pane_C</desc>
+			</g>
+		</g>
+		<clipPath id="clip9a14bc8f-0bd6-49f7-a058-8de63058f47e">
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip39)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m977 240-10 214"/>
+				<title>Segment pane_b</title>
+				<desc>Segment pane_b: Segment pane_C, pane_B</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip40)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m966 454-112 112"/>
+				<title>Segment pane_c</title>
+				<desc>Segment pane_c: Segment pane_B, pane_A</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip41)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m854 566 3.4-229"/>
+				<title>Segment pane_d</title>
+				<desc>Segment pane_d: Segment pane_A, pane_D</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip42)">
+			<g fill="none" stroke="#000" stroke-dasharray="1, 3" stroke-linecap="butt" stroke-linejoin="round">
+				<path d="m701 421 496-78"/>
+				<title>Segment vect_c</title>
+				<desc>Segment vect_c: Segment cube_C, cent_X</desc>
+			</g>
+		</g>
+		<clipPath id="clip0bf765a7-981a-4bd2-915b-68d263ef472a">
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip43)">
+			<g fill="none" stroke="#000" stroke-dasharray="1, 3" stroke-linecap="butt" stroke-linejoin="round">
+				<path d="m703 473 494-130"/>
+				<title>Segment vect_d</title>
+				<desc>Segment vect_d: Segment cube_B, cent_X</desc>
+			</g>
+		</g>
+		<clipPath id="clip19ae7735-ed0e-44f1-82ff-fd3cfc71daeb">
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip44)">
+			<g fill="none" stroke="#000" stroke-dasharray="1, 3" stroke-linecap="butt" stroke-linejoin="round">
+				<path d="m670 500 527-157"/>
+				<title>Segment vect_e</title>
+				<desc>Segment vect_e: Segment cube_A, cent_X</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip45)">
+			<g fill="none" stroke="#000" stroke-dasharray="1, 3" stroke-linecap="butt" stroke-linejoin="round">
+				<path d="m702 448 495-104"/>
+				<title>Segment vect_j</title>
+				<desc>Segment vect_j: Segment vect_A, cent_X</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip46)">
+			<g fill="none" stroke="#000" stroke-dasharray="1, 3" stroke-linecap="butt" stroke-linejoin="round">
+				<path d="m617 432 580-89"/>
+				<title>Segment vect_u</title>
+				<desc>Segment vect_u: Segment cube_H, cent_X</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip47)">
+			<g fill="none" stroke="#000" stroke-dasharray="1, 3" stroke-linecap="butt" stroke-linejoin="round">
+				<path d="m651 406 546-63"/>
+				<title>Segment vect_v</title>
+				<desc>Segment vect_v: Segment cube_G, cent_X</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip48)">
+			<g fill="none" stroke="#000" stroke-dasharray="1, 3" stroke-linecap="butt" stroke-linejoin="round">
+				<path d="m668 447 529-104"/>
+				<title>Segment vect_w</title>
+				<desc>Segment vect_w: Segment cube_D, cent_X</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip49)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m508 495 196-144"/>
+				<title>Segment base_d</title>
+				<desc>Segment base_d: Segment base_D, base_C</desc>
+			</g>
+		</g>
+		<clipPath id="clip0e4a671e-d283-41d9-97cb-d9f44d90d3ce">
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip50)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m508 495 433 142"/>
+				<title>Segment base_b</title>
+				<desc>Segment base_b: Segment base_D, base_A</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip51)">
+			<g>
+				<path d="m1202 343c0 2.8-2.3 5-5 5-2.8 0-5-2.2-5-5s2.2-5 5-5c2.7 0 5 2.2 5 5z"/>
+				<title>Point cent_X</title>
+				<desc>Point cent_X: Point({1108.81775, 528.855})</desc>
+			</g>
+		</g>
+		<clipPath id="clipbbca4491-b62f-4ecc-8d0e-8ff8683c213f">
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip52)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m1202 343c0 2.8-2.3 5-5 5-2.8 0-5-2.2-5-5s2.2-5 5-5c2.7 0 5 2.2 5 5z"/>
+				<title>Point cent_X</title>
+				<desc>Point cent_X: Point({1108.81775, 528.855})</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m487 202v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip53)">
+			<g>
+				<path d="m522 250h-2.4l2.4-11h4.6q1.2 0 2 .29.72.28 1.1.96t.42 1.6q0 .86-.33 1.7-.34.82-.82 1.3-.49.5-1 .75-.56.26-1.5.39-.57.07-2.1.07h-1.5zm1.3-6.3h.74q1.9 0 2.5-.23.63-.23.99-.75t.36-1.1q0-.41-.18-.67-.18-.27-.52-.39-.34-.13-1.5-.13h-1.7zm7 6.3 2.4-11h8.5l-.41 1.9h-6.1l-.55 2.6h5.9l-.39 1.9h-5.9l-.71 3.1h6.7l-.41 1.9zm13 0h-2.4l2.4-11h5.1q1.3 0 2 .26.73.27 1.2.99.44.72.44 1.8 0 1.4-.87 2.4-.88.96-2.6 1.2.45.41.84 1.1.8 1.4 1.8 3.8h-2.5q-.32-.97-1.2-3-.48-1.1-1-1.5-.33-.23-1.2-.23h-.95zm1.4-6.5h1.2q1.9 0 2.5-.23.63-.22.98-.71.35-.48.35-1 0-.63-.52-.94-.31-.19-1.3-.19h-2.6zm8.1 2.8 2.2-.11q.05 1.1.36 1.4.52.61 1.9.61 1.2 0 1.7-.42.52-.41.52-.99 0-.51-.42-.86-.3-.26-1.6-.84t-2-.96q-.61-.38-.96-1-.36-.62-.36-1.4 0-1.4 1-2.4 1-.96 3-.96 2 0 3.1.95 1.1.94 1.2 2.5l-2.3.1q-.08-.82-.58-1.2-.51-.44-1.5-.44-.97 0-1.4.34-.43.35-.43.86 0 .5.4.81.37.33 1.7.91 2 .84 2.5 1.4.81.78.81 2 0 1.5-1.2 2.6-1.2 1.1-3.4 1.1-1.5 0-2.6-.5t-1.5-1.4q-.45-.88-.42-2zm13 3.7h-2.4l2.4-11h4.6q1.2 0 2 .29.72.28 1.1.96t.42 1.6q0 .86-.33 1.7-.34.82-.82 1.3-.49.5-1 .75-.56.26-1.5.39-.57.07-2.1.07h-1.5zm1.3-6.3h.74q1.9 0 2.5-.23.63-.23.99-.75t.36-1.1q0-.41-.18-.67-.18-.27-.52-.39-.34-.13-1.5-.13h-1.7zm7 6.3 2.4-11h8.5l-.41 1.9h-6.1l-.55 2.6h5.9l-.39 1.9h-5.9l-.71 3.1h6.7l-.41 1.9zm19-4.1 2.4.35q-.69 1.9-2.1 3t-3.3 1q-2.1 0-3.3-1.3-1.2-1.3-1.2-3.7 0-2 .8-3.6.79-1.6 2.2-2.5t3.1-.86q1.9 0 3 1t1.4 2.7l-2.3.22q-.19-1-.72-1.4t-1.4-.45q-.99 0-1.8.59-.85.59-1.4 1.9-.51 1.3-.51 2.5 0 1.4.65 2.1.66.75 1.6.75.93 0 1.7-.6.76-.59 1.1-1.7zm8.2 4.1h-2.4l2-9.6h-3.4l.41-1.9h9l-.39 1.9h-3.3zm4.7 0 2.4-11h2.4l-2.4 11zm10 0h-2.5l-2.1-11h2.4l1.4 8.6 4.7-8.6h2.3zm4.9 0 2.4-11h8.5l-.41 1.9h-6.1l-.55 2.6h5.9l-.39 1.9h-5.9l-.72 3.1h6.7l-.41 1.9z"/>
+				<title>PERSPECTIVE</title>
+				<desc>text16 = âPERSPECTIVEâ</desc>
+			</g>
+		</g>
+	</g>
+	<g transform="translate(-1087 -125)" stroke-linecap="square" stroke-miterlimit="10">
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip6)">
+			<g fill="#a0a0a0" fill-opacity=".25" fill-rule="evenodd">
+				<path d="m815 490 3.4-229 119-97-10 214z"/>
+				<title>Quadrilateral pane_{poly}</title>
+				<desc>Quadrilateral pane_{poly}: Polygon pane_A, pane_D, pane_C, pane_B</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip7)">
+			<g fill="#a0a0a0" fill-rule="evenodd">
+				<path d="m468 418 196-144 394 107-157 179z"/>
+				<title>Quadrilateral base_{poly}</title>
+				<desc>Quadrilateral base_{poly}: Polygon base_D, base_C, base_B, base_A</desc>
+			</g>
+		</g>
+		<clipPath id="clipc4072261-d2f9-4043-a7f3-497429beeb7d">
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip8)">
+			<g fill="#808080" fill-rule="evenodd">
+				<path d="m626 358 5.2 26 28 8.7 51-9.7-7-26-28-8.1z"/>
+				<title>Hexagon shad_{poly}</title>
+				<desc>Hexagon shad_{poly}: Polygon shad_E, shad_A, shad_D, shad_C, shad_G, shad_F</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip9)">
+			<g fill="#09f" fill-rule="evenodd">
+				<path d="m621 255 27-36 52 14 7.6 46-28 35-53-12z"/>
+				<title>Hexagon cube_{poly}</title>
+				<desc>Hexagon cube_{poly}: Polygon cube_E, cube_H, cube_G, cube_C, cube_B, cube_A</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip10)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+				<path d="m857 320 22-42"/>
+				<title>Segment proj_l</title>
+				<desc>Segment proj_l: Segment proj_D, proj_H</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip11)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+				<path d="m878 279 19 5"/>
+				<title>Segment proj_m</title>
+				<desc>Segment proj_m: Segment proj_H, proj_G</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip12)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+				<path d="m898 284-21 41"/>
+				<title>Segment proj_n</title>
+				<desc>Segment proj_n: Segment proj_G, proj_C</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip13)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+				<path d="m877 324-20-4.1"/>
+				<title>Segment proj_p</title>
+				<desc>Segment proj_p: Segment proj_C, proj_D</desc>
+			</g>
+		</g>
+		<clipPath id="clip0535f6cd-5981-41bb-943e-2bdcc4ae63da">
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip14)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+				<path d="m898 284-1.7 45"/>
+				<title>Segment proj_q</title>
+				<desc>Segment proj_q: Segment proj_G, proj_F</desc>
+			</g>
+		</g>
+		<clipPath id="clip9763f4ae-4b98-48e8-9291-94981f0d56da">
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip15)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+				<path d="m896 328-21 41"/>
+				<title>Segment proj_r</title>
+				<desc>Segment proj_r: Segment proj_F, proj_B</desc>
+			</g>
+		</g>
+		<clipPath id="clipfed44a59-50df-4542-923c-75879703bd1e">
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip16)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+				<path d="m875 369 1.4-45"/>
+				<title>Segment proj_s</title>
+				<desc>Segment proj_s: Segment proj_B, proj_C</desc>
+			</g>
+		</g>
+		<clipPath id="clipe5928e25-2d94-4e56-83aa-035c4ca4d90d">
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip17)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+				<path d="m875 369-20-2.9"/>
+				<title>Segment proj_t</title>
+				<desc>Segment proj_t: Segment proj_B, proj_A</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip18)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+				<path d="m855 366 1.2-46"/>
+				<title>Segment proj_f</title>
+				<desc>Segment proj_f: Segment proj_A, proj_D</desc>
+			</g>
+		</g>
+		<clipPath id="clip2a13c59b-a5c0-4cf7-aed8-8a71914fe8ac">
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip23)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m621 255 27-36"/>
+				<title>Segment cube_n</title>
+				<desc>Segment cube_n: Segment cube_E, cube_H</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip24)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m648 219 52 14"/>
+				<title>Segment cube_o</title>
+				<desc>Segment cube_o: Segment cube_H, cube_G</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip25)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m701 233 7.6 46"/>
+				<title>Segment cube_q</title>
+				<desc>Segment cube_q: Segment cube_G, cube_C</desc>
+			</g>
+		</g>
+		<clipPath id="clipb76d98ec-9e24-4fb4-ba03-321ecf03cc0a">
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip26)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m708 279-28 35"/>
+				<title>Segment cube_s</title>
+				<desc>Segment cube_s: Segment cube_C, cube_B</desc>
+			</g>
+		</g>
+		<clipPath id="clip742b9db5-9258-4c79-9012-de7b0ab1014d">
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip27)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m680 314-53-12"/>
+				<title>Segment cube_l</title>
+				<desc>Segment cube_l: Segment cube_B, cube_A</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip28)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m628 302-6.2-46"/>
+				<title>Segment cube_m</title>
+				<desc>Segment cube_m: Segment cube_A, cube_E</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip29)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m818 261 119-97"/>
+				<title>Segment pane_m</title>
+				<desc>Segment pane_m: Segment pane_D, pane_C</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip30)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m937 164-10 214"/>
+				<title>Segment pane_n</title>
+				<desc>Segment pane_n: Segment pane_C, pane_B</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip31)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m927 378-112 112"/>
+				<title>Segment pane_o</title>
+				<desc>Segment pane_o: Segment pane_B, pane_A</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip32)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m815 490 3.4-229"/>
+				<title>Segment pane_p</title>
+				<desc>Segment pane_p: Segment pane_A, pane_D</desc>
+			</g>
+		</g>
+		<clipPath id="clip37277681-800a-4e9f-985f-065a9f7d850e">
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip33)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m626 358 50-9.1"/>
+				<title>Segment shad_m</title>
+				<desc>Segment shad_m: Segment shad_E, shad_F</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip34)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m675 349 28 8.1"/>
+				<title>Segment shad_n</title>
+				<desc>Segment shad_n: Segment shad_F, shad_G</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip35)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m703 357 7 26"/>
+				<title>Segment shad_o</title>
+				<desc>Segment shad_o: Segment shad_G, shad_C</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip36)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m710 383-51 9.7"/>
+				<title>Segment shad_p</title>
+				<desc>Segment shad_p: Segment shad_C, shad_D</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip37)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m659 392-28-8.7"/>
+				<title>Segment shad_q</title>
+				<desc>Segment shad_q: Segment shad_D, shad_A</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip38)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m631 384-5.2-26"/>
+				<title>Segment shad_r</title>
+				<desc>Segment shad_r: Segment shad_A, shad_E</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip39)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m468 418 159-117"/>
+				<title>Segment base_a</title>
+				<desc>Segment base_a: Segment base_D, base_E</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip40)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m703 285 355 97"/>
+				<title>Segment base_b</title>
+				<desc>Segment base_b: Segment base_F, base_B</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip41)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m1058 382-157 179"/>
+				<title>Segment base_c</title>
+				<desc>Segment base_c: Segment base_B, base_A</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip42)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m901 560-433-142"/>
+				<title>Segment base_d</title>
+				<desc>Segment base_d: Segment base_A, base_D</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip43)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m648 219 6.8 47"/>
+				<title>Segment cube_r</title>
+				<desc>Segment cube_r: Segment cube_H, cube_D</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip44)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m655 266-28 36"/>
+				<title>Segment cube_t</title>
+				<desc>Segment cube_t: Segment cube_D, cube_A</desc>
+			</g>
+		</g>
+		<clipPath id="clip647ef359-ed63-4f01-a562-00c03f2445fe">
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip45)">
+			<g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m655 266 53 13"/>
+				<title>Segment cube_u</title>
+				<desc>Segment cube_u: Segment cube_D, cube_C</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip46)">
+			<g fill="none" stroke="#000" stroke-dasharray="1, 3" stroke-linecap="butt" stroke-linejoin="round">
+				<path d="m708 278 188 51"/>
+				<title>Segment vect_a</title>
+				<desc>Segment vect_a: Segment vect_A, proj_F</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip47)">
+			<g fill="none" stroke="#000" stroke-dasharray="1, 3" stroke-linecap="butt" stroke-linejoin="round">
+				<path d="m708 279 168 46"/>
+				<title>Segment vect_c</title>
+				<desc>Segment vect_c: Segment cube_C, proj_C</desc>
+			</g>
+		</g>
+		<clipPath id="clip053254e4-b399-495d-92b4-79a2c6b6354f">
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip48)">
+			<g fill="none" stroke="#000" stroke-dasharray="1, 3" stroke-linecap="butt" stroke-linejoin="round">
+				<path d="m680 314 195 55"/>
+				<title>Segment vect_d</title>
+				<desc>Segment vect_d: Segment cube_B, proj_B</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip49)">
+			<g fill="none" stroke="#000" stroke-dasharray="1, 3" stroke-linecap="butt" stroke-linejoin="round">
+				<path d="m628 302 228 64"/>
+				<title>Segment vect_e</title>
+				<desc>Segment vect_e: Segment cube_A, proj_A</desc>
+			</g>
+		</g>
+		<clipPath id="clipf8d9bd55-f805-40ec-b9f2-4d3b0f277a8d">
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip50)">
+			<g fill="none" stroke="#000" stroke-dasharray="1, 3" stroke-linecap="butt" stroke-linejoin="round">
+				<path d="m648 219 230 59"/>
+				<title>Segment vect_u</title>
+				<desc>Segment vect_u: Segment cube_H, proj_H</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip51)">
+			<g fill="none" stroke="#000" stroke-dasharray="1, 3" stroke-linecap="butt" stroke-linejoin="round">
+				<path d="m701 233 197 51"/>
+				<title>Segment vect_v</title>
+				<desc>Segment vect_v: Segment cube_G, proj_G</desc>
+			</g>
+		</g>
+		<clipPath>
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip52)">
+			<g fill="none" stroke="#000" stroke-dasharray="1, 3" stroke-linecap="butt" stroke-linejoin="round">
+				<path d="m655 266 201 55"/>
+				<title>Segment vect_w</title>
+				<desc>Segment vect_w: Segment cube_D, proj_D</desc>
+			</g>
+		</g>
+		<clipPath id="clip03c8180c-ff05-43e9-90f4-26fcce0cc08b">
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip53)">
+			<g>
+				<path d="m481 174 2.4-11h2.4l-2.4 11zm4.9-3.7 2.2-.11q.05 1.1.36 1.4.52.61 1.9.61 1.2 0 1.7-.42.51-.41.51-.99 0-.51-.42-.86-.29-.26-1.6-.84t-2-.96-.97-1-.35-1.4q0-1.4 1-2.4 1-.96 3-.96 2 0 3.1.95 1.1.94 1.2 2.5l-2.3.1q-.08-.82-.59-1.2-.51-.44-1.5-.44-.96 0-1.4.34-.42.35-.42.86 0 .5.39.81.38.33 1.7.91 2 .84 2.5 1.4.81.78.81 2 0 1.5-1.2 2.6-1.2 1.1-3.3 1.1-1.5 0-2.6-.5-1.1-.5-1.5-1.4-.45-.88-.42-2zm11-.78q0-1 .3-2.1.41-1.5 1.2-2.6t2-1.8q1.2-.65 2.8-.65 2.1 0 3.4 1.3 1.3 1.3 1.3 3.5 0 1.8-.85 3.5t-2.3 2.6-3.3.91q-1.6 0-2.7-.72-1.1-.73-1.5-1.8-.46-1.1-.46-2.2zm2.3-.05q0 1.2.72 2 .72.79 1.9.79.95 0 1.8-.63.87-.63 1.4-1.9.58-1.3.58-2.5 0-1.3-.73-2.1-.72-.78-1.8-.78-1.7 0-2.8 1.6t-1.1 3.5zm16 4.6h-2.2l-.42-9.6-1.8 9.6h-2.1l2.4-11h3.4l.34 8 3.9-8h3.4l-2.4 11h-2.1l2.2-9.5zm6.7 0 2.4-11h8.5l-.41 1.9h-6.1l-.55 2.6h5.9l-.39 1.9h-5.9l-.72 3.1h6.7l-.41 1.9zm16 0h-2.4l2-9.6h-3.4l.41-1.9h9l-.39 1.9h-3.3zm7.2 0h-2.4l2.4-11h5.1q1.3 0 2 .26.73.27 1.2.99t.45 1.8q0 1.4-.88 2.4-.87.96-2.6 1.2.45.41.84 1.1.8 1.4 1.8 3.8h-2.5q-.31-.97-1.2-3-.48-1.1-1-1.5-.32-.23-1.2-.23h-.95zm1.4-6.5h1.2q1.9 0 2.5-.23.63-.22.98-.71.35-.48.35-1 0-.63-.51-.94-.32-.19-1.4-.19h-2.6zm7.7 6.5 2.4-11h2.4l-2.4 11zm13-4.1 2.4.35q-.68 1.9-2.1 3t-3.3 1q-2.1 0-3.3-1.3-1.2-1.3-1.2-3.7 0-2 .8-3.6.8-1.6 2.2-2.5 1.4-.86 3.1-.86 1.9 0 3 1t1.4 2.7l-2.3.22q-.19-1-.72-1.4t-1.4-.45q-.99 0-1.8.59t-1.4 1.9q-.51 1.3-.51 2.5 0 1.4.66 2.1.65.75 1.6.75.92 0 1.7-.6.75-.59 1.1-1.7z"/>
+				<title>ISOMETRIC
+(ORTHOGRAPHIC)</title>
+				<desc>text1 = âISOMETRIC
+(ORTHOGRAPHIC)â</desc>
+			</g>
+		</g>
+		<clipPath id="clip1b32284a-0780-4064-87c2-71eef4cf4e5f">
+			<path d="m448 126v482h642v-482z"/>
+		</clipPath>
+		<g clip-path="url(#clip54)">
+			<g>
+				<path d="m484 201h-1.5q-.64-1.5-.94-3-.31-1.5-.31-2.8 0-1.6.51-3.2t1.6-3.3q.66-1.1 2.1-2.7h1.7q-1.5 1.8-2.3 3.3t-1.2 3.4q-.4 1.8-.4 3.6 0 1.2.18 2.3t.6 2.6zm2.9-7.9q0-1 .3-2.1.41-1.5 1.2-2.6t2-1.8q1.2-.65 2.8-.65 2.1 0 3.4 1.3 1.3 1.3 1.3 3.5 0 1.8-.86 3.5-.85 1.7-2.3 2.6t-3.3.91q-1.6 0-2.7-.72-1.1-.73-1.5-1.8-.46-1.1-.46-2.2zm2.3-.05q0 1.2.72 2 .72.79 1.9.79.95 0 1.8-.63t1.4-1.9q.58-1.3.58-2.5 0-1.3-.73-2.1-.72-.78-1.8-.78-1.7 0-2.8 1.6t-1.1 3.5zm12 4.6h-2.4l2.4-11h5.1q1.3 0 2 .26.73.27 1.2.99.44.72.44 1.8 0 1.4-.87 2.4-.88.96-2.6 1.2.45.41.84 1.1.8 1.4 1.8 3.8h-2.5q-.32-.97-1.2-3-.48-1.1-1-1.5-.33-.23-1.2-.23h-.95zm1.4-6.5h1.2q1.9 0 2.5-.23.63-.22.98-.71.35-.48.35-1 0-.63-.52-.94-.31-.19-1.3-.19h-2.6zm13 6.5h-2.4l2-9.6h-3.4l.41-1.9h9l-.39 1.9h-3.3zm13-5.1h-4.4l-1.1 5.1h-2.4l2.4-11h2.4l-.92 4.4h4.4l.94-4.4h2.4l-2.4 11h-2.4zm4.4.62q0-1 .3-2.1.41-1.5 1.2-2.6t2-1.8q1.2-.65 2.8-.65 2.1 0 3.4 1.3 1.3 1.3 1.3 3.5 0 1.8-.85 3.5t-2.3 2.6-3.3.91q-1.6 0-2.7-.72-1.1-.73-1.5-1.8-.46-1.1-.46-2.2zm2.3-.05q0 1.2.72 2 .72.79 1.9.79.95 0 1.8-.63.87-.63 1.4-1.9.58-1.3.58-2.5 0-1.3-.73-2.1-.72-.78-1.8-.78-1.7 0-2.8 1.6t-1.1 3.5zm16-1.6h5.1l-1 4.9q-.91.58-2.2.99t-2.7.41q-2.1 0-3.2-.97-1.6-1.3-1.6-3.8 0-1.7.66-3.2.8-1.8 2.3-2.9 1.5-1 3.4-1 2 0 3.2.93 1.2.92 1.6 2.7l-2.2.25q-.28-.97-.93-1.5t-1.6-.49q-1.1 0-2.1.59-.96.6-1.5 1.8t-.54 2.7q0 1.4.66 2.1t1.9.69q.75 0 1.6-.21t1.4-.51l.36-1.7h-2.9zm8.5 6.1h-2.4l2.4-11h5.1q1.3 0 2 .26.74.27 1.2.99.45.72.45 1.8 0 1.4-.88 2.4-.87.96-2.6 1.2.45.41.84 1.1.8 1.4 1.8 3.8h-2.5q-.31-.97-1.2-3-.49-1.1-1-1.5-.32-.23-1.2-.23h-.95zm1.4-6.5h1.2q1.9 0 2.5-.23.63-.22.98-.71.35-.48.35-1 0-.63-.51-.94-.32-.19-1.4-.19h-2.6zm15 3.9h-4.5l-1.4 2.5h-2.4l6.5-11h2.6l1.9 11h-2.2zm-.28-1.9-.68-4.6-2.8 4.6zm6.7 4.4h-2.4l2.4-11h4.7q1.2 0 2 .29.72.28 1.1.96t.42 1.6q0 .86-.34 1.7-.33.82-.82 1.3-.48.5-1 .75-.57.26-1.5.39-.56.07-2.1.07h-1.5zm1.3-6.3h.73q1.9 0 2.5-.23.62-.23.98-.75t.36-1.1q0-.41-.18-.67-.18-.27-.51-.39-.34-.13-1.5-.13h-1.7zm15 1.2h-4.4l-1.1 5.1h-2.4l2.4-11h2.4l-.92 4.4h4.4l.94-4.4h2.3l-2.4 11h-2.4zm3.6 5.1 2.4-11h2.4l-2.4 11zm13-4.1 2.4.35q-.69 1.9-2.1 3t-3.3 1q-2.1 0-3.3-1.3-1.2-1.3-1.2-3.7 0-2 .8-3.6.8-1.6 2.2-2.5 1.4-.86 3.1-.86 1.9 0 3 1 1.2 1 1.4 2.7l-2.3.22q-.19-1-.72-1.4t-1.4-.45q-.98 0-1.8.59-.84.59-1.4 1.9-.51 1.3-.51 2.5 0 1.4.66 2.1.65.75 1.6.75.92 0 1.7-.6.76-.59 1.1-1.7zm4.5-7.5h1.5q.64 1.5.95 3t.31 2.8q0 1.6-.51 3.2-.52 1.6-1.6 3.3-.68 1.1-2.1 2.7h-1.7q1.5-1.8 2.3-3.3.81-1.5 1.2-3.4.4-1.8.4-3.6 0-1.2-.17-2.3t-.6-2.6z"/>
+				<title>ISOMETRIC
+(ORTHOGRAPHIC)</title>
+				<desc>text1 = âISOMETRIC
+(ORTHOGRAPHIC)â</desc>
+			</g>
+		</g>
+	</g>
+	<path d="m95 1h-734" fill="#fff" fill-opacity=".071" stop-color="#000000" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" style="paint-order:stroke markers fill"/>
+</svg>

--- a/content/learn/book/rendering/3d/camera/_index.md
+++ b/content/learn/book/rendering/3d/camera/_index.md
@@ -12,7 +12,6 @@ The first thing you will need if you want to render anything is a camera.
 
 At it's core a camera is simply a 2d projection of the 3d scene. The most common type of projection used for 3d games is a perspective projection. Which is a projection that takes into account the distance between the camera and a vertex.
 
-<!-- TODO we need a lighter background for this image -->
 [![camera projection](Various_projections_of_cube_above_plane.svg)](https://en.wikipedia.org/wiki/3D_projection#/media/File:Various_projections_of_cube_above_plane.svg)
 
 In bevy just like most things in the engine a `Camera` is just a component. To simplify spawning a `Camera` with all the required components we can use a `PerspectiveCameraBundle`. This `Bundle` will spawn the camera and every other components required by bevy to render an image. If you prefer an orthographic projection you can use the `OrthographicCameraBundle`.

--- a/content/learn/book/rendering/3d/shapes_and_meshes/Mesh_overview.svg
+++ b/content/learn/book/rendering/3d/shapes_and_meshes/Mesh_overview.svg
@@ -1,410 +1,111 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   version="1.0"
-   id="svg5212"
-   height="271"
-   width="720">
-  <defs
-     id="defs5214" />
-  <metadata
-     id="metadata5217">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     id="layer1">
-    <path
-       id="path3813"
-       d="M 466.10943,175.64462 L 447.07034,201.26463"
-       style="opacity:0.74074073;fill:#808080;fill-rule:evenodd;stroke:#110f0f;stroke-width:0.23829247;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="opacity:0.74074073;fill:#808080;fill-rule:evenodd;stroke:#110f0f;stroke-width:0.23829247;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 464.72428,61.10341 L 439.97335,89.09156"
-       id="path3809" />
-    <path
-       transform="matrix(0.7043699,0,0,0.8863127,15.429598,-235.44194)"
-       d="M 52.022857,489.70721 A 2.0203052,2.0203052 0 1 1 47.982247,489.70721 A 2.0203052,2.0203052 0 1 1 52.022857,489.70721 z"
-       id="path2580"
-       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1" />
-    <path
-       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1"
-       id="path2584"
-       d="M 52.022857,489.70721 A 2.0203052,2.0203052 0 1 1 47.982247,489.70721 A 2.0203052,2.0203052 0 1 1 52.022857,489.70721 z"
-       transform="matrix(0.7043699,0,0,0.8863127,-8.4196104,-273.1944)" />
-    <path
-       transform="matrix(0.7043699,0,0,0.8863127,35.242785,-262.09075)"
-       d="M 52.022857,489.70721 A 2.0203052,2.0203052 0 1 1 47.982247,489.70721 A 2.0203052,2.0203052 0 1 1 52.022857,489.70721 z"
-       id="path2586"
-       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1" />
-    <path
-       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1"
-       id="path2588"
-       d="M 52.022857,489.70721 A 2.0203052,2.0203052 0 1 1 47.982247,489.70721 A 2.0203052,2.0203052 0 1 1 52.022857,489.70721 z"
-       transform="matrix(0.7043699,0,0,0.8863127,58.541627,-278.62289)" />
-    <path
-       transform="matrix(0.7043699,0,0,0.8863127,80.739734,-240.13017)"
-       d="M 52.022857,489.70721 A 2.0203052,2.0203052 0 1 1 47.982247,489.70721 A 2.0203052,2.0203052 0 1 1 52.022857,489.70721 z"
-       id="path2590"
-       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1" />
-    <path
-       transform="matrix(0.7043699,0,0,0.8863127,11.026671,-345.98514)"
-       d="M 52.022857,489.70721 A 2.0203052,2.0203052 0 1 1 47.982247,489.70721 A 2.0203052,2.0203052 0 1 1 52.022857,489.70721 z"
-       id="path2592"
-       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1" />
-    <path
-       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1"
-       id="path2594"
-       d="M 52.022857,489.70721 A 2.0203052,2.0203052 0 1 1 47.982247,489.70721 A 2.0203052,2.0203052 0 1 1 52.022857,489.70721 z"
-       transform="matrix(0.7043699,0,0,0.8863127,31.20677,-372.14045)" />
-    <path
-       transform="matrix(0.7043699,0,0,0.8863127,76.520258,-349.93312)"
-       d="M 52.022857,489.70721 A 2.0203052,2.0203052 0 1 1 47.982247,489.70721 A 2.0203052,2.0203052 0 1 1 52.022857,489.70721 z"
-       id="path2596"
-       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1" />
-    <path
-       transform="matrix(0.7043699,0,0,0.8863127,53.771787,-388.17909)"
-       d="M 52.022857,489.70721 A 2.0203052,2.0203052 0 1 1 47.982247,489.70721 A 2.0203052,2.0203052 0 1 1 52.022857,489.70721 z"
-       id="path2598"
-       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1" />
-    <path
-       transform="matrix(0.7043699,0,0,0.8863127,-12.272176,-383.98436)"
-       d="M 52.022857,489.70721 A 2.0203052,2.0203052 0 1 1 47.982247,489.70721 A 2.0203052,2.0203052 0 1 1 52.022857,489.70721 z"
-       id="path2600"
-       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1" />
-    <g
-       transform="matrix(1.0273505,0,0,1.3817898,-7.8162233e-2,-476.60014)"
-       id="g2802">
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 188.39345,403.33917 L 237.89092,399.29856"
-         id="path2602" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 182.33253,410.91532 L 182.83761,461.42294"
-         id="path2604" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 190.41375,460.41279 L 238.90108,404.34932"
-         id="path2606" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 246.9823,405.86455 L 246.9823,459.40264"
-         id="path2608" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 247.99245,388.69196 L 223.74879,363.43815"
-         id="path2610" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 218.19295,362.17546 L 157.33126,367.98383"
-         id="path2614" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 158.59395,377.58028 L 180.05969,399.29856"
-         id="path2616" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 184.60538,397.02572 L 198.49498,383.38866"
-         id="path2618" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 198.24244,379.34805 L 165.66502,372.27698"
-         id="path2620" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 205.06097,378.08536 L 219.2031,365.71099"
-         id="path2622" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 208.34396,381.36835 L 242.18407,388.69196"
-         id="path2624" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 154.04826,389.70211 L 153.79573,448.03842"
-         id="path2626" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 160.61425,437.43182 L 177.28177,407.63232"
-         id="path2628" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 159.85664,468.99909 L 218.95056,463.19071"
-         id="path2630" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 224.75894,463.69579 L 249.76022,489.95975"
-         id="path2632" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 240.16377,497.03082 L 189.15106,501.32397"
-         id="path2634" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 185.36299,497.28336 C 185.27881,497.28336 185.19463,497.28336 185.36299,497.28336 z"
-         id="path2636" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 179.55462,499.80874 L 158.84649,477.83792"
-         id="path2638" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 186.12061,497.28336 L 199.00005,483.6463"
-         id="path2640" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 209.86261,482.3401 L 242.68572,489.75071"
-         id="path2642" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 206.32366,478.59554 L 220.71833,465.71609"
-         id="path2644" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 198.74751,479.10061 L 166.67517,473.0397"
-         id="path2646" />
-    </g>
-    <g
-       transform="matrix(1.0273505,0,0,1.3817898,-7.8162233e-2,-476.60014)"
-       id="g2766">
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 321.48105,496.77828 L 365.17014,493.24275 L 333.35034,485.41407 L 321.48105,496.77828 z"
-         id="path2648" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 337.39095,481.37346 L 348.25009,471.52447 L 368.45314,487.43437 L 337.39095,481.37346 z"
-         id="path2650" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 331.33004,479.35315 L 342.18918,470.00924 L 302.79322,473.54477 L 331.33004,479.35315 z"
-         id="path2652" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 313.65237,495.01052 L 326.78434,482.63615 L 296.98485,477.33285 L 313.65237,495.01052 z"
-         id="path2654" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 302.54069,465.46355 L 302.79323,413.94577 L 284.61048,448.03842 L 302.54069,465.46355 z"
-         id="path2656" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 283.34779,392.98511 L 301.78307,410.41024 L 283.34779,445.00796 L 283.34779,392.98511 z"
-         id="path2658" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 315.92521,403.33917 L 327.28943,391.97496 L 359.36177,399.29856 L 315.92521,403.33917 z"
-         id="path2660" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 308.6016,401.5714 L 320.4709,389.95465 L 291.68155,385.15643 L 308.6016,401.5714 z"
-         id="path2662" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 325.26912,386.41912 L 337.39095,376.82267 L 296.98484,380.3582 L 325.26912,386.41912 z"
-         id="path2664" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 331.0775,387.93435 L 342.18918,378.59043 L 364.15999,395.25795 L 331.0775,387.93435 z"
-         id="path2666" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 310.87445,464.70594 C 310.79027,464.62176 310.70609,464.53758 310.87445,464.70594 z"
-         id="path2668" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 311.12698,465.71609 L 311.12698,414.70339 L 360.37192,410.41024 L 311.12698,465.71609 z"
-         id="path2670" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 314.91506,467.23132 L 362.8973,411.67293 L 363.14984,463.94832 L 314.91506,467.23132 z"
-         id="path2672" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 367.19045,442.48258 L 384.61558,408.38993 L 384.86812,457.63487 L 367.19045,442.48258 z"
-         id="path2674" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 365.92776,436.92674 L 383.85797,404.34932 L 366.43284,386.92419 L 365.92776,436.92674 z"
-         id="path2676" />
-    </g>
-    <path
-       id="path2678"
-       d="M 443.31367,173.20282 L 428.52528,175.6455 L 447.20534,201.11919 L 497.01881,193.79116 L 475.7443,174.59864"
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.1914624px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path2682"
-       d="M 443.57311,178.08818 L 443.83255,106.55247 L 494.6838,100.62028 L 494.16492,172.85386 L 443.57311,178.08818 z"
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.1914624px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path2684"
-       d="M 436.82753,172.15596 L 436.82753,99.573377 L 418.92582,76.19343 L 418.40692,149.4739 L 436.82753,172.15596 z"
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.1914624px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path2686"
-       d="M 439.94087,89.80266 L 489.49491,83.87044 L 464.84762,60.83942 L 419.70416,64.67792 L 439.94087,89.80266 z"
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.1914624px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       id="path2688"
-       d="M 494.94325,151.21869 L 507.39663,168.66641 L 508.17496,96.781747 L 490.0138,73.40179 L 489.75435,101.31816"
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.1914624px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    <g
-       transform="matrix(1.0273505,0,0,1.3817898,-7.8162233e-2,-476.60014)"
-       id="g2790">
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 509.11688,403.84424 L 508.86435,455.8671 L 527.29963,472.78716 L 527.29963,421.52191 L 509.11688,403.84424 z"
-         id="path2690" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 527.29963,421.77446 L 577.04964,417.48131 L 576.54457,469.50416 L 527.55217,473.0397 L 527.29963,421.77446 z"
-         id="path2694" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 577.04964,417.73385 L 551.54329,400.05618 L 509.36942,403.08663"
-         id="path2696" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 551.03822,400.56125 L 551.29075,419.50161"
-         id="path2698" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 578.56487,494.75798 C 578.98577,495.01051 579.40666,495.26305 579.82756,495.51559 L 532.09785,499.80874 L 514.16765,481.62599 L 556.34151,478.343 L 579.82756,495.26305"
-         id="path2700" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 528.30978,387.93435 L 511.13719,370.00414 L 552.80598,366.97368 L 573.93996,383.38866 L 528.30978,387.93435 z"
-         id="path2702" />
-    </g>
-    <path
-       id="path2706"
-       d="M 631.15199,78.98505 L 676.55489,74.09972 L 700.94274,97.828627 L 650.35092,103.06294"
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.1914624px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    <g
-       transform="matrix(1.0273505,0,0,1.3817898,-7.8162233e-2,-476.60014)"
-       id="g2798">
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 614.60386,402.24236 L 615.43544,454.85695 L 632.35549,471.01939 L 633.36564,419.24908 L 614.60386,402.24236 z"
-         id="path2704" />
-      <path
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 633.11311,470.76685 L 682.10551,467.23132 L 682.10551,416.21862"
-         id="path2708" />
-    </g>
-    <text
-       transform="scale(0.8622601,1.1597428)"
-       id="text2838"
-       y="222.83949"
-       x="219.55879"
-       style="font-size:15.00000043px;font-style:normal;font-weight:normal;fill:#008000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';font-stretch:normal;font-variant:normal;"
-       xml:space="preserve"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';font-size:15.00000043px;"
-         y="222.83949"
-         x="219.55879"
-         id="tspan2840">edges</tspan></text>
-    <text
-       transform="scale(0.8622601,1.1597428)"
-       xml:space="preserve"
-       style="font-size:15.00000043px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000080;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';"
-       x="53.467724"
-       y="223.6656"
-       id="text2842"><tspan
-         style="-inkscape-font-specification:'DejaVu Sans';font-family:'DejaVu Sans';font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;font-size:15.00000043px;"
-         id="tspan2844"
-         x="53.467724"
-         y="223.6656">vertices</tspan></text>
-    <text
-       transform="scale(0.8622601,1.1597428)"
-       id="text2850"
-       y="223.6656"
-       x="377.18787"
-       style="font-size:15.00000043px;font-style:normal;font-weight:normal;fill:#b50303;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';font-stretch:normal;font-variant:normal;"
-       xml:space="preserve"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';font-size:15.00000043px;"
-         y="223.6656"
-         x="377.18787"
-         id="tspan2852">faces</tspan></text>
-    <text
-       transform="scale(0.8622601,1.1597428)"
-       xml:space="preserve"
-       style="font-size:15.00000043px;font-style:normal;font-weight:normal;fill:#34d1d1;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';font-stretch:normal;font-variant:normal;"
-       x="511.10815"
-       y="223.6656"
-       id="text2854"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';font-size:15.00000043px;"
-         id="tspan2856"
-         x="511.10815"
-         y="223.6656">polygons</tspan></text>
-    <text
-       transform="scale(0.8622601,1.1597428)"
-       id="text2858"
-       y="223.6656"
-       x="620.36517"
-       style="font-size:15.00000043px;font-style:normal;font-weight:normal;fill:#800080;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';font-stretch:normal;font-variant:normal;"
-       xml:space="preserve"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';font-size:15.00000043px;"
-         y="223.6656"
-         x="620.36517"
-         id="tspan2860">surfaces</tspan></text>
-    <path
-       style="opacity:0.74074073;fill:#808080;fill-rule:evenodd;stroke:#110f0f;stroke-width:0.23829247;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 494.38895,100.96832 L 443.69755,177.53572"
-       id="path3803" />
-    <path
-       id="path3807"
-       d="M 436.47213,100.58313 L 418.50906,149.29813"
-       style="opacity:0.74074073;fill:#808080;fill-rule:evenodd;stroke:#110f0f;stroke-width:0.23829247;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       id="path3811"
-       d="M 489.49077,83.064 L 419.79325,64.91024"
-       style="opacity:0.74074073;fill:#808080;fill-rule:evenodd;stroke:#110f0f;stroke-width:0.23829247;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="opacity:0.74074073;fill:#808080;fill-rule:evenodd;stroke:#110f0f;stroke-width:0.23829247;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 496.46451,192.74338 L 429.68752,175.79094"
-       id="path3815" />
-    <path
-       id="path3817"
-       d="M 507.88009,97.478787 L 494.02993,126.58833"
-       style="opacity:0.61777775;fill:#808080;fill-rule:evenodd;stroke:#110f0f;stroke-width:0.23829247;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       id="path3819"
-       d="M 592.35416,101.46182 L 541.66276,178.02921"
-       style="opacity:0.61777775;fill:#808080;fill-rule:evenodd;stroke:#110f0f;stroke-width:0.23829247;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="opacity:0.74074073;fill:#808080;fill-rule:evenodd;stroke:#110f0f;stroke-width:0.23829247;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 541.77556,105.51809 L 522.71176,152.2591"
-       id="path3821" />
-    <path
-       style="opacity:0.74074073;fill:#808080;fill-rule:evenodd;stroke:#110f0f;stroke-width:0.23829247;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 589.11772,52.35598 L 525.128,34.900127"
-       id="path3827" />
-    <path
-       id="path3829"
-       d="M 567.98347,31.093297 L 543.23254,59.08148"
-       style="opacity:0.74074073;fill:#808080;fill-rule:evenodd;stroke:#110f0f;stroke-width:0.23829247;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       id="path3831"
-       d="M 592.23646,206.0801 L 528.98056,190.10475"
-       style="opacity:0.74074073;fill:#808080;fill-rule:evenodd;stroke:#110f0f;stroke-width:0.23829247;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="opacity:0.74074073;fill:#808080;fill-rule:evenodd;stroke:#110f0f;stroke-width:0.23829247;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 571.1022,184.81743 L 547.0851,214.77956"
-       id="path3833" />
-    <path
-       style="opacity:0.74074073;fill:#808080;fill-rule:evenodd;stroke:#110f0f;stroke-width:0.23829247;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 565.93656,77.28051 L 542.02968,106.96573"
-       id="path3835" />
-  </g>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="720.8" height="256.9" version="1.0" xmlns="http://www.w3.org/2000/svg">
+	<rect x="607.5" y="-3.683e-7" width="113.2" height="256.9" fill="#fff" fill-opacity=".1279" stop-color="#000000" style="paint-order:stroke markers fill"/>
+	<g transform="translate(-5.409 -10.85)" fill="none" stroke="#000">
+		<path d="m634.3 78.99 45.4-4.885 24.39 23.73-50.59 5.234" stroke-width="1.191px"/>
+		<g transform="matrix(1.027 0 0 1.382 3.052 -476.6)" stroke-width="1px">
+			<path d="m614.6 402.2.8316 52.61 16.92 16.16 1.01-51.77z"/>
+			<path d="m633.1 470.8 48.99-3.536v-51.01"/>
+		</g>
+	</g>
+	<rect x="121.5" y="-3.683e-7" width="113.2" height="256.9" fill="#fff" fill-opacity=".1279" stop-color="#000000" style="paint-order:stroke markers fill"/>
+	<g transform="translate(-5.409 -10.85)" fill="none" stroke="#000" stroke-width="1.191px">
+		<path d="m171.1 80.73 50.85-5.583"/>
+		<path d="m164.9 91.2.5189 69.79"/>
+		<path d="m173.2 159.6 49.81-77.47"/>
+		<path d="m231.3 84.22v73.98"/>
+		<path d="m232.3 60.49-24.91-34.9"/>
+		<path d="m201.7 23.85-62.53 8.026"/>
+		<path d="m140.5 45.14 22.05 30.01"/>
+		<path d="m167.2 72.01 14.27-18.84"/>
+		<path d="m181.2 47.58-33.47-9.771"/>
+		<path d="m188.2 45.83 14.53-17.1"/>
+		<path d="m191.6 50.37 34.77 10.12"/>
+		<path d="m135.8 61.89-.2594 80.61"/>
+		<path d="m142.6 127.8 17.12-41.18"/>
+		<path d="m141.8 171.5 60.71-8.026"/>
+		<path d="m208.5 164.1 25.69 36.29"/>
+		<path d="m224.3 210.2-52.41 5.932"/>
+		<path d="m168 210.5c-.0865 0-.173 0 0 0z"/>
+		<path d="m162 214-21.27-30.36"/>
+		<path d="m168.8 210.5 13.23-18.84"/>
+		<path d="m193.2 189.9 33.72 10.24"/>
+		<path d="m189.5 184.7 14.79-17.8"/>
+		<path d="m181.7 185.4-32.95-8.375"/>
+	</g>
+	<text transform="scale(.8623 1.16)" x="187.34174" y="213.48656" fill="#008000" font-family="'DejaVu Sans'" font-size="15px" stroke-width="1px" xml:space="preserve"><tspan x="187.34174" y="213.48656" font-family="'DejaVu Sans'" font-size="15px">edges</tspan></text>
+	<rect x="243" y="-3.683e-7" width="113.2" height="256.9" fill="#fff" fill-opacity=".1279" stop-color="#000000" style="paint-order:stroke markers fill"/>
+	<g transform="matrix(1.027 0 0 1.382 -43.87 -487.4)" fill="none" stroke="#000" stroke-width="1px">
+		<path d="m321.5 496.8 43.69-3.536-31.82-7.829z"/>
+		<path d="m337.4 481.4 10.86-9.849 20.2 15.91z"/>
+		<path d="m331.3 479.4 10.86-9.344-39.4 3.536z"/>
+		<path d="m313.7 495 13.13-12.37-29.8-5.303z"/>
+		<path d="m302.5 465.5.2525-51.52-18.18 34.09z"/>
+		<path d="m283.3 393 18.44 17.43-18.44 34.6z"/>
+		<path d="m315.9 403.3 11.36-11.36 32.07 7.324z"/>
+		<path d="m308.6 401.6 11.87-11.62-28.79-4.798z"/>
+		<path d="m325.3 386.4 12.12-9.596-40.41 3.536z"/>
+		<path d="m331.1 387.9 11.11-9.344 21.97 16.67z"/>
+		<path d="m310.9 464.7c-.0842-.0842-.1684-.1684 0 0z"/>
+		<path d="m311.1 465.7v-51.01l49.24-4.293z"/>
+		<path d="m314.9 467.2 47.98-55.56.2525 52.28z"/>
+		<path d="m367.2 442.5 17.43-34.09.2525 49.24z"/>
+		<path d="m365.9 436.9 17.93-32.58-17.43-17.43z"/>
+	</g>
+	<text transform="scale(.8623 1.16)" x="326.40256" y="214.31267" fill="#d52626" font-family="'DejaVu Sans'" font-size="15px" stroke-width="1px" xml:space="preserve"><tspan x="326.40256" y="214.31267" fill="#d52626" font-family="'DejaVu Sans'" font-size="15px">faces</tspan></text>
+	<rect x="364.5" y="-3.683e-7" width="113.2" height="256.9" fill="#fff" fill-opacity=".1279" stop-color="#000000" style="paint-order:stroke markers fill"/>
+	<text transform="scale(.8623 1.16)" x="462.69653" y="214.31267" fill="#34d1d1" font-family="'DejaVu Sans'" font-size="15px" stroke-width="1px" xml:space="preserve"><tspan x="462.69653" y="214.31267" font-family="'DejaVu Sans'" font-size="15px">polygons</tspan></text>
+	<g transform="translate(-5.409 -10.85)">
+		<path d="m429.8 175.6-19.04 25.62" fill="#808080" fill-rule="evenodd" opacity=".7407" stroke="#110f0f" stroke-width=".2383"/>
+		<path d="m428.4 61.1-24.75 27.99" fill="#808080" fill-rule="evenodd" opacity=".7407" stroke="#110f0f" stroke-width=".2383"/>
+		<g fill="none" stroke="#000" stroke-width="1.191px">
+			<path d="m407 173.2-14.79 2.443 18.68 25.47 49.81-7.328-21.27-19.19"/>
+			<path d="m407.2 178.1.2594-71.54 50.85-5.932-.5189 72.23z"/>
+			<path d="m400.5 172.2v-72.58l-17.9-23.38-.5189 73.28z"/>
+			<path d="m403.6 89.8 49.55-5.932-24.65-23.03-45.14 3.838z"/>
+			<path d="m458.6 151.2 12.45 17.45.7783-71.88-18.16-23.38-.2594 27.92"/>
+		</g>
+		<g fill="#808080" fill-rule="evenodd" stroke="#110f0f" stroke-width=".2383">
+			<path d="m458.1 101-50.69 76.57" opacity=".7407"/>
+			<path d="m400.1 100.6-17.96 48.72" opacity=".7407"/>
+			<path d="m453.2 83.06-69.7-18.15" opacity=".7407"/>
+			<path d="m460.1 192.7-66.78-16.95" opacity=".7407"/>
+			<path d="m471.5 97.48-13.85 29.11" opacity=".6178"/>
+		</g>
+	</g>
+	<rect x="486" y="-3.683e-7" width="113.2" height="256.9" fill="#fff" fill-opacity=".1279" stop-color="#000000" style="paint-order:stroke markers fill"/>
+	<text transform="scale(.8623 1.16)" x="601.45264" y="214.31267" fill="#ff06ff" font-family="'DejaVu Sans'" font-size="15px" stroke-width="1px" xml:space="preserve"><tspan x="601.45264" y="214.31267" fill="#ff06ff" font-family="'DejaVu Sans'" font-size="15px">surfaces</tspan></text>
+	<g transform="translate(-5.131 -10.85)">
+		<g transform="matrix(1.027 0 0 1.382 -10.98 -476.6)" fill="none" stroke="#000" stroke-width="1px">
+			<path d="m509.1 403.8-.2525 52.02 18.44 16.92v-51.27z"/>
+			<path d="m527.3 421.8 49.75-4.293-.5051 52.02-48.99 3.536z"/>
+			<path d="m577 417.7-25.51-17.68-42.17 3.03"/>
+			<path d="m551 400.6.2525 18.94"/>
+			<path d="m578.6 494.8c.4209.2525.8418.5051 1.263.7576l-47.73 4.293-17.93-18.18 42.17-3.283 23.49 16.92"/>
+			<path d="m528.3 387.9-17.17-17.93 41.67-3.03 21.13 16.41z"/>
+		</g>
+		<g fill="#808080" fill-rule="evenodd" stroke="#110f0f" stroke-width=".2383">
+			<path d="m581.5 101.5-50.69 76.57" opacity=".6178"/>
+			<path d="m530.9 105.5-19.06 46.74" opacity=".7407"/>
+			<path d="m578.2 52.36-63.99-17.46" opacity=".7407"/>
+			<path d="m557.1 31.09-24.75 27.99" opacity=".7407"/>
+			<path d="m581.3 206.1-63.26-15.98" opacity=".7407"/>
+			<path d="m560.2 184.8-24.02 29.96" opacity=".7407"/>
+			<path d="m555 77.28-23.91 29.69" opacity=".7407"/>
+		</g>
+	</g>
+	<rect x="1.072e-8" y="-3.683e-7" width="113.2" height="256.9" fill="#fff" fill-opacity=".1279" stop-color="#000000" style="paint-order:stroke markers fill"/>
+	<g transform="translate(-5.409 -10.85)" stroke="#000" stroke-width=".7901">
+		<path d="m42.99 198.6a1.423 1.791 0 11-2.846 0 1.423 1.791 0 112.846 0z"/>
+		<path d="m19.14 160.8a1.423 1.791 0 11-2.846 0 1.423 1.791 0 112.846 0z"/>
+		<path d="m62.8 171.9a1.423 1.791 0 11-2.846 0 1.423 1.791 0 112.846 0z"/>
+		<path d="m86.1 155.4a1.423 1.791 0 11-2.846 0 1.423 1.791 0 112.846 0z"/>
+		<path d="m108.3 193.9a1.423 1.791 0 11-2.846 0 1.423 1.791 0 112.846 0z"/>
+		<path d="m38.58 88.05a1.423 1.791 0 11-2.846 0 1.423 1.791 0 112.846 0z"/>
+		<path d="m58.76 61.89a1.423 1.791 0 11-2.846 0 1.423 1.791 0 112.846 0z"/>
+		<path d="m104.1 84.1a1.423 1.791 0 11-2.846 0 1.423 1.791 0 112.846 0z"/>
+		<path d="m81.33 45.85a1.423 1.791 0 11-2.846 0 1.423 1.791 0 112.846 0z"/>
+		<path d="m15.29 50.05a1.423 1.791 0 11-2.846 0 1.423 1.791 0 112.846 0z"/>
+	</g>
+	<text transform="scale(.8623 1.16)" x="36.657734" y="214.31267" fill="#8686d5" font-family="'DejaVu Sans'" font-size="15px" stroke-width="1px" xml:space="preserve"><tspan x="36.657734" y="214.31267" fill="#8686d5" font-family="'DejaVu Sans'" font-size="15px">vertices</tspan></text>
 </svg>


### PR DESCRIPTION
This makes the diagrams more readable by adding a semitransparent background layer and removes some irrelevant info from the perspective diagram.

The assets also happen to have much lower size