### PR TITLE
Move serialization format thing closer to the other one

### DIFF
--- a/content/learn/book/migration-guides/0.8-0.9/_index.md
+++ b/content/learn/book/migration-guides/0.8-0.9/_index.md
@@ -772,44 +772,6 @@ Note: You can still derive `Clone`, but it’s not required in order to compile.
 * relax `T: ?Sized` bound in `Mut<T>`
 * replace all instances of `ReflectMut` with `Mut<dyn Reflect>`
 
-### [Update enum derives](https://github.com/bevyengine/bevy/pull/5473)
-
-Bevy-defined enums have been updated to implement `Enum` and are not considered value types (`ReflectRef::Value`) anymore. This means that their serialized representations will need to be updated. For example, given the Bevy enum:
-
-```rust
-pub enum ScalingMode {
-  None,
-  WindowSize,
-  Auto { min_width: f32, min_height: f32 },
-  FixedVertical(f32),
-  FixedHorizontal(f32),
-}
-```
-
-You will need to update the serialized versions accordingly.
-
-```js
-// OLD FORMAT
-{
-  "type": "bevy_render::camera::projection::ScalingMode",
-  "value": FixedHorizontal(720),
-},
-
-// NEW FORMAT
-{
-  "type": "bevy_render::camera::projection::ScalingMode",
-  "enum": {
-    "variant": "FixedHorizontal",
-    "tuple": [
-      {
-        "type": "f32",
-        "value": 720,
-      },
-    ],
-  },
-},
-```
-
 ### [remove blanket `Serialize + Deserialize` requirement for `Reflect` on generic types](https://github.com/bevyengine/bevy/pull/5197)
 
 `.register_type` for generic types like `Option<T>`, `Vec<T>`, `HashMap<K, V>` will no longer insert `ReflectSerialize` and `ReflectDeserialize` type data. Instead you need to register it separately for concrete generic types like so:


### PR DESCRIPTION
It seems that most of the changes suggested by the current guide for `#5473` are not necessary after `#5723`.

I think the other section on serialization covers the rest, so I believe we can just delete this one.

Here's what I actually see when serializing `ScalingMode` with 0.8 and bevy main

```js
// 0.8
{
    "type": "bevy_render::camera::projection::ScalingMode",
    "value": FixedHorizontal(720.0),
}

// bevy main
{
    "bevy_render::camera::projection::ScalingMode": FixedHorizontal(720.0),
}
```