### PR TITLE
Generate TOML file for contributors instead of a MD file

### DIFF
--- a/generate-release/src/contributors.rs
+++ b/generate-release/src/contributors.rs
@@ -41,12 +41,11 @@ pub fn generate_contributors(
 
     let mut output = String::new();
 
-    writeln!(output, "## Contributors\n")?;
-    writeln!(output, "A huge thanks to the {} contributors that made this release (and associated docs) possible! In random order:\n", contributors.len())?;
-    for author in &contributors {
-        writeln!(output, "- @{author}")?;
+    for name in &contributors {
+        writeln!(output, r#"[[contributors]]
+name = "{name}"
+"#)?;
     }
-    writeln!(output)?;
 
     std::fs::write(path, output).context("Writing contributors file")?;
 

--- a/generate-release/src/main.rs
+++ b/generate-release/src/main.rs
@@ -109,7 +109,7 @@ fn main() -> anyhow::Result<()> {
         Commands::Contributors => generate_contributors(
             &args.from,
             &args.to,
-            release_path.join("contributors.md"),
+            release_path.join("contributors.toml"),
             &client,
         )?,
     };

--- a/templates/shortcodes/contributors.md
+++ b/templates/shortcodes/contributors.md
@@ -1,0 +1,8 @@
+{% set data = load_data(path=path) %}
+## Contributors
+
+A huge thanks to the {{ data.contributors | length }} contributors that made this release (and associated docs) possible! In random order:
+
+{% for contributor in data.contributors %}
+- @{{ contributor.name }}
+{% endfor %}


### PR DESCRIPTION
I noticed I introduced some extraneous commits… so, I've just created another branch and applied the suggestion from the previous PR. This just moves contributors to a TOML, but doesn't touch the rendering or the `@` prefix.

Replaces: https://github.com/IceSentry/bevy-website/pull/9