### PR TITLE
Generate TOML file for the changelog instead of a MD file

### DIFF
--- a/generate-release/README.md
+++ b/generate-release/README.md
@@ -93,7 +93,7 @@ Sponsorships help make our work on Bevy sustainable. If you believe in Bevy's mi
 {{ contributors(path="./release-content/0.14/contributors.toml") }}
 
 <!-- Changelog -->
-{{ load_markdown(md_path = "./release-content/0.14/changelog.md") }}
+{{ changelog(path="./release-content/0.14/changelog.toml")}}
 ```
 
 The most important part of this is the `combine_release_notes` shortcode and the `load_markdown()` shortcode for the contributors and changelog. `combine_release_notes` will get the list of release notes from the `_release_notes.toml` file and combine all the separate file and add them to this file. `load_markdown()` will load a markdown file and add it to the blog post.

--- a/generate-release/src/changelog.rs
+++ b/generate-release/src/changelog.rs
@@ -50,13 +50,13 @@ pub fn generate_changelog(
 
         for (title, pr) in prs {
             writeln!(output, "[[areas.prs]]")?;
-            writeln!(output, "title = \"{}\"", title.trim().replace("\"", "\\\""))?;
+            writeln!(output, "title = \"{}\"", title.trim().replace('"', "\\\""))?;
             writeln!(output, "number = {}", pr.number)?;
 
             count += 1;
         }
 
-        writeln!(output, "")?;
+        writeln!(output)?;
     }
 
     println!("\nAdded {count} PRs to the changelog");

--- a/generate-release/src/changelog.rs
+++ b/generate-release/src/changelog.rs
@@ -27,18 +27,23 @@ pub fn generate_changelog(
     let mut areas_vec: Vec<_> = areas.into_iter().collect();
 
     // Move empty areas to the end
-    areas_vec.sort_by(|(a, _), (b, _)| {
-        match (a.is_empty(), b.is_empty()) {
-            (false, false) => a.join(" ").cmp(&b.join(" ")),
-            (false, true) => std::cmp::Ordering::Less,
-            (true, false) => std::cmp::Ordering::Greater,
-            (true, true) => std::cmp::Ordering::Equal,
-        }
+    areas_vec.sort_by(|(a, _), (b, _)| match (a.is_empty(), b.is_empty()) {
+        (false, false) => a.join(" ").cmp(&b.join(" ")),
+        (false, true) => std::cmp::Ordering::Less,
+        (true, false) => std::cmp::Ordering::Greater,
+        (true, true) => std::cmp::Ordering::Equal,
     });
 
     for (area, prs) in areas_vec {
         writeln!(output, "[[areas]]")?;
-        writeln!(output, "name = [{}]", area.iter().map(|a| format!("\"{}\"", a)).collect::<Vec<_>>().join(", "))?;
+        writeln!(
+            output,
+            "name = [{}]",
+            area.iter()
+                .map(|a| format!("\"{}\"", a))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )?;
 
         let mut prs = prs;
         prs.sort_by_key(|k| k.1.closed_at);

--- a/generate-release/src/changelog.rs
+++ b/generate-release/src/changelog.rs
@@ -12,7 +12,7 @@ pub fn generate_changelog(
 ) -> anyhow::Result<()> {
     let mut output = String::new();
 
-    let mut areas = BTreeMap::<String, Vec<(String, GithubIssuesResponse)>>::new();
+    let mut areas = BTreeMap::<Vec<String>, Vec<(String, GithubIssuesResponse)>>::new();
 
     let merged_prs = get_merged_prs(client, from, to, None)?;
     for (pr, _, title) in &merged_prs {
@@ -23,29 +23,35 @@ pub fn generate_changelog(
             .push((title.clone(), pr.clone()));
     }
 
-    writeln!(output, "## Full Changelog")?;
-    writeln!(output, "The changes mentioned above are only the most appealing, highest impact changes that we've made this cycle.
-Innumerable bug fixes, documentation changes and API usability tweaks made it in too.
-For a complete list of changes, check out the PRs listed below.")?;
-
     let mut count = 0;
-    for (area, prs) in areas {
-        writeln!(output)?;
-        writeln!(output, "### {area}")?;
-        writeln!(output)?;
+    let mut areas_vec: Vec<_> = areas.into_iter().collect();
+
+    // Move empty areas to the end
+    areas_vec.sort_by(|(a, _), (b, _)| {
+        match (a.is_empty(), b.is_empty()) {
+            (false, false) => a.join(" ").cmp(&b.join(" ")),
+            (false, true) => std::cmp::Ordering::Less,
+            (true, false) => std::cmp::Ordering::Greater,
+            (true, true) => std::cmp::Ordering::Equal,
+        }
+    });
+
+    for (area, prs) in areas_vec {
+        writeln!(output, "[[areas]]")?;
+        writeln!(output, "name = [{}]", area.iter().map(|a| format!("\"{}\"", a)).collect::<Vec<_>>().join(", "))?;
 
         let mut prs = prs;
         prs.sort_by_key(|k| k.1.closed_at);
 
         for (title, pr) in prs {
-            writeln!(
-                output,
-                "* [{}](https://github.com/bevyengine/bevy/pull/{})",
-                title.trim(),
-                pr.number
-            )?;
+            writeln!(output, "[[areas.prs]]")?;
+            writeln!(output, "title = \"{}\"", title.trim().replace("\"", "\\\""))?;
+            writeln!(output, "number = {}", pr.number)?;
+
             count += 1;
         }
+
+        writeln!(output, "")?;
     }
 
     println!("\nAdded {count} PRs to the changelog");

--- a/generate-release/src/contributors.rs
+++ b/generate-release/src/contributors.rs
@@ -46,9 +46,12 @@ pub fn generate_contributors(
     let mut output = String::new();
 
     for name in &contributors {
-        writeln!(output, r#"[[contributors]]
+        writeln!(
+            output,
+            r#"[[contributors]]
 name = "{name}"
-"#)?;
+"#
+        )?;
     }
 
     std::fs::write(path, output).context("Writing contributors file")?;

--- a/generate-release/src/helpers.rs
+++ b/generate-release/src/helpers.rs
@@ -83,7 +83,7 @@ pub fn get_pr_area(pr: &GithubIssuesResponse) -> Vec<String> {
         .map(|l| l.replace("A-", ""))
         .collect();
 
-    areas.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+    areas.sort_by_key(|a| a.to_lowercase());
 
     areas
 }

--- a/generate-release/src/helpers.rs
+++ b/generate-release/src/helpers.rs
@@ -74,18 +74,18 @@ fn get_pr_title_from_commit(commit: &GithubCommitResponse) -> Option<String> {
 }
 
 /// Returns all the area label for a PR as a list separated with ' + '
-pub fn get_pr_area(pr: &GithubIssuesResponse) -> String {
-    let areas: Vec<String> = pr
+pub fn get_pr_area(pr: &GithubIssuesResponse) -> Vec<String> {
+    let mut areas: Vec<String> = pr
         .labels
         .iter()
         .map(|l| l.name.clone())
         .filter(|l| l.starts_with("A-"))
+        .map(|l| l.replace("A-", ""))
         .collect();
-    if areas.is_empty() {
-        String::from("No area label")
-    } else {
-        areas.join(" + ")
-    }
+
+    areas.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+
+    areas
 }
 
 /// Gets a list of all authors and co-authors for the given commit

--- a/generate-release/src/main.rs
+++ b/generate-release/src/main.rs
@@ -103,7 +103,7 @@ fn main() -> anyhow::Result<()> {
         Commands::Changelog => generate_changelog(
             &args.from,
             &args.to,
-            release_path.join("changelog.md"),
+            release_path.join("changelog.toml"),
             &client,
         )?,
         Commands::Contributors => generate_contributors(

--- a/generate-release/src/migration_guides.rs
+++ b/generate-release/src/migration_guides.rs
@@ -100,7 +100,8 @@ fn get_prs_by_areas(
         // We want to check for PRs with the breaking label but without the guide section
         // to make it easier to track down missing guides
         if has_migration_guide_section || has_breaking_label {
-            let area = get_pr_area(pr);
+            let area = get_pr_area(pr).join(" + ");
+
             areas
                 .entry(area)
                 .or_default()

--- a/generate-release/src/migration_guides.rs
+++ b/generate-release/src/migration_guides.rs
@@ -7,6 +7,8 @@ use crate::{
 };
 use std::{collections::BTreeMap, io::Write as IoWrite, path::PathBuf};
 
+type PrsByAreaBTreeMap = BTreeMap<Vec<String>, Vec<(String, GithubIssuesResponse)>>;
+
 pub fn generate_migration_guides(
     from: &str,
     to: &str,
@@ -76,8 +78,8 @@ fn get_prs_by_areas(
     client: &GithubClient,
     from: &str,
     to: &str,
-) -> Result<BTreeMap<Vec<String>, Vec<(String, GithubIssuesResponse)>>, anyhow::Error> {
-    let mut areas = BTreeMap::<Vec<String>, Vec<(String, GithubIssuesResponse)>>::new();
+) -> Result<PrsByAreaBTreeMap, anyhow::Error> {
+    let mut areas: PrsByAreaBTreeMap = BTreeMap::new();
 
     let merged_prs = get_merged_prs(client, from, to, None)?;
     let mut count = 0;
@@ -114,7 +116,7 @@ fn get_prs_by_areas(
 fn generate_metadata_block(
     title: &String,
     file_name: &String,
-    areas: &Vec<String>,
+    areas: &[String],
     pr_number: i32,
 ) -> String {
     format!(

--- a/sass/components/_pr-list.scss
+++ b/sass/components/_pr-list.scss
@@ -1,0 +1,10 @@
+.pr-list {
+  text-wrap: pretty;
+
+  &__item {
+    p {
+      display: inline;
+      margin: 0;
+    }
+  }
+}

--- a/sass/site.scss
+++ b/sass/site.scss
@@ -43,6 +43,7 @@
 @import "components/menu-switch";
 @import "components/on-this-page";
 @import "components/page-with-menu";
+@import "components/pr-list";
 @import "components/sponsors";
 @import "components/syntax-theme";
 @import "components/tree-menu";

--- a/templates/shortcodes/changelog.md
+++ b/templates/shortcodes/changelog.md
@@ -7,7 +7,12 @@ Innumerable bug fixes, documentation changes and API usability tweaks made it in
 For a complete list of changes, check out the PRs listed below.
 
 {% for area in data.areas %}
+{% set area_name_length = area.name | length %}
+{% if area_name_length > 0 %}
 ### {{ area.name | join(sep=" + ") }}
+{% else %}
+### No area label
+{% endif %}
 
 <ul>
 {% for pr in area.prs %}

--- a/templates/shortcodes/changelog.md
+++ b/templates/shortcodes/changelog.md
@@ -14,9 +14,9 @@ For a complete list of changes, check out the PRs listed below.
 ### No area label
 {% endif %}
 
-<ul>
+<ul class="pr-list">
 {% for pr in area.prs %}
-<li><a href="https://github.com/bevyengine/bevy/pull/{{pr.number}}">{{pr.title | escape}}</a></li>
+<li class="pr-list__item"><a href="https://github.com/bevyengine/bevy/pull/{{pr.number}}">{{pr.title | markdown}}</a></li>
 {% endfor %}
 </ul>
 {% endfor %}

--- a/templates/shortcodes/changelog.md
+++ b/templates/shortcodes/changelog.md
@@ -1,0 +1,17 @@
+{% set data = load_data(path=path) %}
+
+## Full Changelog
+
+The changes mentioned above are only the most appealing, highest impact changes that we've made this cycle.
+Innumerable bug fixes, documentation changes and API usability tweaks made it in too.
+For a complete list of changes, check out the PRs listed below.
+
+{% for area in data.areas %}
+### {{ area.name | join(sep=" + ") }}
+
+<ul>
+{% for pr in area.prs %}
+<li><a href="https://github.com/bevyengine/bevy/pull/{{pr.number}}">{{pr.title | escape}}</a></li>
+{% endfor %}
+</ul>
+{% endfor %}

--- a/templates/shortcodes/combine_migration_guides.md
+++ b/templates/shortcodes/combine_migration_guides.md
@@ -8,9 +8,9 @@
 ### [{{ guide.title }}]({{ guide.url }})
 
 <div class="migration-guide-area-tags">
-  {% for area in guide.areas %}
-    <div class="migration-guide-area-tag">{{ area }}</div>
-  {% endfor %}
+{% for area in guide.areas %}
+<div class="migration-guide-area-tag">{{ area }}</div>
+{% endfor %}
 </div>
 
 {{ guide_body }}


### PR DESCRIPTION
In a similar fashion to #10, change changelog to generate TOML, use a shortcode to render the TOML file.

Also:
- Remove `A-` prefix from area names
- Sort areas names
- Sort changelog areas by their name, leave PRs without area in the end