### PR TITLE
Remove contributors spacing by generating the HTML directly instead of using MD

### DIFF
--- a/templates/shortcodes/contributors.md
+++ b/templates/shortcodes/contributors.md
@@ -4,6 +4,8 @@
 
 A huge thanks to the {{ data.contributors | length }} contributors that made this release (and associated docs) possible! In random order:
 
+<ul>
 {% for contributor in data.contributors %}
-- {{ contributor.name }}
+<li>{{ contributor.name }}</li>
 {% endfor %}
+</ul>


### PR DESCRIPTION
The MD code introduced `<p>` elements which added extra margin.  
So, instead generate HTML directly instead without inner `<p>` element.

<img width="330" alt="image" src="https://github.com/IceSentry/bevy-website/assets/188612/a277fe87-f98c-41a7-a90e-71c4c2ebea09">

<img width="330" alt="image" src="https://github.com/IceSentry/bevy-website/assets/188612/a873d27f-d5e9-45be-b3d6-5085e916016b">
