### PR TITLE
Tweak `generate-release` related templates as discussed in discord

### DIFF
--- a/generate-release/README.md
+++ b/generate-release/README.md
@@ -43,10 +43,6 @@ weight = 9
 long_title = "Migration Guide: 0.13 to 0.14"
 +++
 
-{% callout(type="warning") %}
-    Bevy relies heavily on improvements in the Rust language and compiler. As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable release" of Rust.
-{% end %}
-
 {{ migration_guides(version="0.14") }}
 ```
 

--- a/generate-release/README.md
+++ b/generate-release/README.md
@@ -46,7 +46,7 @@ long_title = "Migration Guide: 0.13 to 0.14"
 {{ migration_guides(version="0.14") }}
 ```
 
-The most important part of this is the `migrations_guides` shortcode. It will get the list of guides from the `_guides.toml` file and combine all the separate file and generate appropritate markup for it.
+The most important part of this is the `migrations_guides` shortcode. It will get the list of guides from the `_guides.toml` file and combine all the separate file and generate appropriate markup for it.
 
 Remember to update the weight to be higher than the previous guides.
 

--- a/generate-release/README.md
+++ b/generate-release/README.md
@@ -47,7 +47,7 @@ long_title = "Migration Guide: 0.13 to 0.14"
     Bevy relies heavily on improvements in the Rust language and compiler. As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable release" of Rust.
 {% end %}
 
-{{ migration_guides(path="./release-content/0.14/migration-guides/") }}
+{{ migration_guides(version="0.14") }}
 ```
 
 The most important part of this is the `migrations_guides` shortcode. It will get the list of guides from the `_guides.toml` file and combine all the separate file and generate appropritate markup for it.
@@ -78,23 +78,15 @@ public_draft = _release tracking issue number_
 
 <!-- more -->
 
-{{ combine_release_notes(release_content_path = "./release-content/0.14/") }}
+{{ release_notes(version="0.14") }}
 
-## <a name="what-s-next"></a>What's Next?
+## What's Next?
 
 <!-- TODO What's next -->
 
-## Support Bevy
-
-Sponsorships help make our work on Bevy sustainable. If you believe in Bevy's mission, consider [sponsoring us](/donate) ... every bit helps!
-
-<a class="button button--pink header__cta" href="/donate">Donate <img class="button__icon" src="/assets/heart.svg" alt="heart icon"></a>
-
-<!-- Contributors -->
-{{ contributors(path="./release-content/0.14/contributors.toml") }}
-
-<!-- Changelog -->
-{{ changelog(path="./release-content/0.14/changelog.toml")}}
+{{ support_bevy() }}
+{{ contributors(version="0.14") }}
+{{ changelog(version="0.14")}}
 ```
 
 The most important part of this is the `combine_release_notes`, `changelog`, and `contributors` shortcodes. `combine_release_notes` will get the list of release notes from the `_release_notes.toml` file and combine all the separate file and add them to this file. `contributors()` will load the `contributors.md` file and generate the necessary markup. `changelog()` will load the `changelog.md` file and generate the necessary markup.

--- a/templates/macros/path.html
+++ b/templates/macros/path.html
@@ -1,2 +1,4 @@
 {# joins 2 paths together to form a longer path #}
 {% macro path_join(path_a, path_b) %}{{ path_a | split(pat="/") | concat(with=path_b) | join(sep="/") }}{% endmacro build_path %}
+
+{% macro release_path(version, path) %}{{ "./release-content/" ~ version ~ path }}{% endmacro build_path %}

--- a/templates/shortcodes/changelog.md
+++ b/templates/shortcodes/changelog.md
@@ -1,4 +1,5 @@
-{% set data = load_data(path=path) %}
+{% import "macros/path.html" as macros %}
+{% set data = load_data(path=macros::release_path(version=version, path="/changelog.toml")) %}
 
 ## Full Changelog
 

--- a/templates/shortcodes/combine_release_notes.md
+++ b/templates/shortcodes/combine_release_notes.md
@@ -1,8 +1,0 @@
-{% import "macros/path_join.html" as macros %}
-
-{% set release_notes_path = macros::path_join(path_a=release_content_path, path_b="/release-notes/") %}
-{% set release_notes_data = load_data(path=macros::path_join(path_a=release_notes_path, path_b="/_release-notes.toml")) %}
-{% for release_note in release_notes_data.release_notes %}
-  {% set release_note_content = load_data(path=macros::path_join(path_a=release_notes_path, path_b=release_note.file_name)) %}
-  {{ release_note_content | safe }}
-{% endfor %}

--- a/templates/shortcodes/contributors.md
+++ b/templates/shortcodes/contributors.md
@@ -1,4 +1,5 @@
-{% set data = load_data(path=path) %}
+{% import "macros/path.html" as macros %}
+{% set data = load_data(path=macros::release_path(version=version, path="/contributors.toml")) %}
 
 ## Contributors
 

--- a/templates/shortcodes/migration_guides.md
+++ b/templates/shortcodes/migration_guides.md
@@ -3,6 +3,10 @@
 {% set base_path = macros::release_path(version=version, path="/migration-guides/") %}
 {% set guides_data = load_data(path=macros::path_join(path_a=base_path, path_b="/_guides.toml")) %}
 
+<aside class="callout callout--warning">
+  <p>Bevy relies heavily on improvements in the Rust language and compiler. As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable release" of Rust.</p>
+</aside>
+
 <div class="migration-guide">
 {% for guide in guides_data.guides %}
 {% set guide_body = load_data(path=macros::path_join(path_a=base_path, path_b=guide.file_name)) %}

--- a/templates/shortcodes/migration_guides.md
+++ b/templates/shortcodes/migration_guides.md
@@ -1,9 +1,11 @@
-{% import "macros/path_join.html" as macros %}
+{% import "macros/path.html" as macros %}
+
+{% set base_path = macros::release_path(version=version, path="/migration-guides/") %}
+{% set guides_data = load_data(path=macros::path_join(path_a=base_path, path_b="/_guides.toml")) %}
 
 <div class="migration-guide">
-{% set guides_data = load_data(path=macros::path_join(path_a=path, path_b="/_guides.toml")) %}
 {% for guide in guides_data.guides %}
-{% set guide_body = load_data(path=macros::path_join(path_a = path, path_b = guide.file_name)) %}
+{% set guide_body = load_data(path=macros::path_join(path_a=base_path, path_b=guide.file_name)) %}
 
 ### [{{ guide.title }}]({{ guide.url }})
 

--- a/templates/shortcodes/release_notes.md
+++ b/templates/shortcodes/release_notes.md
@@ -1,0 +1,8 @@
+{% import "macros/path.html" as macros %}
+
+{% set base_path = macros::release_path(version=version, path="/release-notes/") %}
+{% set release_notes_data = load_data(path=macros::path_join(path_a=base_path, path_b="/_release-notes.toml")) %}
+{% for release_note in release_notes_data.release_notes %}
+  {% set release_note_content = load_data(path=macros::path_join(path_a=base_path, path_b=release_note.file_name)) %}
+  {{ release_note_content | safe }}
+{% endfor %}

--- a/templates/shortcodes/support_bevy.md
+++ b/templates/shortcodes/support_bevy.md
@@ -1,0 +1,5 @@
+## Support Bevy
+
+Sponsorships help make our work on Bevy sustainable. If you believe in Bevy's mission, consider [sponsoring us](/donate)… every bit helps!
+
+<a class="button button--pink" href="/donate">Donate <img class="button__icon" src="/assets/heart.svg" alt="heart icon"></a>


### PR DESCRIPTION
- Use `version` parameter in shortcodes
- Move "Support Bevy" to its own shortcode
- Remove `combine_*` prefix in shortcodes
- Update README 