### PR TITLE
Move `title`, `authors` and PR `url` to the release notes TOML

### DIFF
--- a/generate-release/src/migration_guides.rs
+++ b/generate-release/src/migration_guides.rs
@@ -114,7 +114,7 @@ fn get_prs_by_areas(
 
 /// Generates the metadata markdown section for the given values
 fn generate_metadata_block(
-    title: &String,
+    title: &str,
     file_name: &String,
     areas: &[String],
     pr_number: i32,
@@ -131,6 +131,7 @@ file_name = "{file_name}.md"
             .map(|area| format!("\"{area}\""))
             .collect::<Vec<_>>()
             .join(","),
+        title = title.trim().replace('"', "\\\"")
     )
 }
 

--- a/sass/pages/_news.scss
+++ b/sass/pages/_news.scss
@@ -46,6 +46,13 @@
   color: $subtitle-color;
 }
 
+.release-feature-meta {
+  @extend .release-feature-authors;
+
+  padding: 0 !important;
+  list-style: none;
+}
+
 .news-image-subtitle {
   color: $subtitle-color;
   font-style: italic;

--- a/templates/shortcodes/release_notes.md
+++ b/templates/shortcodes/release_notes.md
@@ -3,6 +3,15 @@
 {% set base_path = macros::release_path(version=version, path="/release-notes/") %}
 {% set release_notes_data = load_data(path=macros::path_join(path_a=base_path, path_b="/_release-notes.toml")) %}
 {% for release_note in release_notes_data.release_notes %}
-  {% set release_note_content = load_data(path=macros::path_join(path_a=base_path, path_b=release_note.file_name)) %}
-  {{ release_note_content | safe }}
+{% set release_note_body = load_data(path=macros::path_join(path_a=base_path, path_b=release_note.file_name)) %}
+
+### {{ release_note.title }}
+
+<ul class="release-feature-meta">
+  <li>Authors: {{ release_note.authors | join(sep=", ")}}</li>
+  <li><a href="{{ release_note.url }}">Pull Request</a></li>
+</ul>
+
+{{ release_note_body }}
+
 {% endfor %}


### PR DESCRIPTION
Also, the PR author will be the first "author".

Result (for now):

<img width="480" alt="image" src="https://github.com/IceSentry/bevy-website/assets/188612/0a1359e4-91b2-4a66-9516-8feb01e67d46">

---

This generates a TOML like this:

```toml
[[release_notes]]
title = "Add support for KHR_texture_transform"
authors = ["@janhohenheim","@Kanabenki","@yrns"]
url = "https://github.com/bevyengine/bevy/pull/11904"
file_name = "11904_Add_support_for_KHR_texture_transform.md"
```

---

See: https://github.com/bevyengine/bevy-website/pull/1194